### PR TITLE
fix(layout): cap section height on tall viewports, trim hero intro

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -16,6 +16,7 @@
   --frame-max: 1280px;
   --frame-gutter: clamp(1.5rem, 4vw, 4rem);
   --frame-pad-y: clamp(4rem, 9vw, 7rem);
+  --frame-min-h-cap: 54rem;
 
   /* Type scale: micro and CTA are fixed; body and headlines scale with viewport. */
   --fs-micro: 0.6875rem;

--- a/components/site/Hero.tsx
+++ b/components/site/Hero.tsx
@@ -19,20 +19,20 @@ export function Hero() {
           className="hug flex flex-col font-semibold leading-[0.9] tracking-[-0.04em]"
           style={{ fontSize: "var(--fs-h1)" }}
         >
-          <span className="rise rise-1">the delivery layer</span>
-          <span className="rise rise-2 pl-[4vw]">
+          <span className="rise rise-0">the delivery layer</span>
+          <span className="rise rise-1 pl-[4vw]">
             anyone can serve
             <span aria-hidden style={{ color: "var(--whisper)" }}>
               .
             </span>
           </span>
-          <span className="rise rise-2 pl-[8vw]">priced, not quoted.</span>
+          <span className="rise rise-1 pl-[8vw]">priced, not quoted.</span>
         </h1>
 
         <div className="grid gap-10 @4xl:grid-cols-[minmax(0,1fr)_minmax(0,440px)] @4xl:items-end @4xl:gap-12">
           <div className="flex flex-col gap-8 @4xl:gap-12">
             <p
-              className="rise rise-3 max-w-[64ch] leading-[1.65]"
+              className="rise rise-2 max-w-[64ch] leading-[1.65]"
               style={{ fontSize: "var(--fs-body)" }}
             >
               a 14-gigabyte file posted in berlin reaches a client in tokyo in
@@ -47,7 +47,7 @@ export function Hero() {
               price is posted.
             </p>
 
-            <div className="rise rise-4 flex flex-col flex-wrap gap-x-8 gap-y-3 @md:flex-row @md:items-end">
+            <div className="rise rise-3 flex flex-col flex-wrap gap-x-8 gap-y-3 @md:flex-row @md:items-end">
               <a
                 className="underline-brutal font-semibold tracking-[0.14em] uppercase"
                 style={{ fontSize: "var(--fs-cta)" }}
@@ -82,7 +82,7 @@ export function Hero() {
               </a>
             </div>
 
-            <div className="rise rise-5 grid grid-cols-2 gap-y-4 @xl:grid-cols-4">
+            <div className="rise rise-4 grid grid-cols-2 gap-y-4 @xl:grid-cols-4">
               <Figure label="target price" value="$0.01/GB" />
               <Figure label="p50 latency" value="50–100 ms" />
               <Figure label="settlement" value="per-MB · usdc" />

--- a/components/site/Hero.tsx
+++ b/components/site/Hero.tsx
@@ -26,13 +26,13 @@ export function Hero() {
               .
             </span>
           </span>
-          <span className="rise rise-1 pl-[8vw]">priced, not quoted.</span>
+          <span className="rise rise-2 pl-[8vw]">priced, not quoted.</span>
         </h1>
 
         <div className="grid gap-10 @4xl:grid-cols-[minmax(0,1fr)_minmax(0,440px)] @4xl:items-end @4xl:gap-12">
           <div className="flex flex-col gap-8 @4xl:gap-12">
             <p
-              className="rise rise-2 max-w-[64ch] leading-[1.65]"
+              className="rise rise-3 max-w-[64ch] leading-[1.65]"
               style={{ fontSize: "var(--fs-body)" }}
             >
               a 14-gigabyte file posted in berlin reaches a client in tokyo in
@@ -47,7 +47,7 @@ export function Hero() {
               price is posted.
             </p>
 
-            <div className="rise rise-3 flex flex-col flex-wrap gap-x-8 gap-y-3 @md:flex-row @md:items-end">
+            <div className="rise rise-4 flex flex-col flex-wrap gap-x-8 gap-y-3 @md:flex-row @md:items-end">
               <a
                 className="underline-brutal font-semibold tracking-[0.14em] uppercase"
                 style={{ fontSize: "var(--fs-cta)" }}
@@ -82,7 +82,7 @@ export function Hero() {
               </a>
             </div>
 
-            <div className="rise rise-4 grid grid-cols-2 gap-y-4 @xl:grid-cols-4">
+            <div className="rise rise-5 grid grid-cols-2 gap-y-4 @xl:grid-cols-4">
               <Figure label="target price" value="$0.01/GB" />
               <Figure label="p50 latency" value="50–100 ms" />
               <Figure label="settlement" value="per-MB · usdc" />

--- a/components/site/Hero.tsx
+++ b/components/site/Hero.tsx
@@ -13,26 +13,7 @@ export function Hero() {
         timestamp="2026-04 · devnet v0.0.0"
       />
 
-      <div className="mt-auto flex flex-col gap-8 @4xl:gap-12">
-        <div className="rise rise-0 flex flex-wrap items-center gap-3">
-          <span className="meta inline-flex items-center gap-2">
-            <span
-              aria-hidden
-              className="inline-block h-[8px] w-[8px] rounded-full"
-              style={{ background: "var(--whisper)" }}
-            />
-            <span>live</span>
-          </span>
-          <span className="meta opacity-50" aria-hidden>
-            ·
-          </span>
-          <span className="meta opacity-70">epoch 00042</span>
-          <span className="meta opacity-50" aria-hidden>
-            ·
-          </span>
-          <span className="meta opacity-70">quic / blake3</span>
-        </div>
-
+      <div className="mt-10 flex flex-col gap-8 @4xl:gap-12">
         <h1
           id="intro-h"
           className="hug flex flex-col font-semibold leading-[0.9] tracking-[-0.04em]"

--- a/components/ui/Frame.tsx
+++ b/components/ui/Frame.tsx
@@ -20,7 +20,7 @@ export function Frame({ id, tone, className = "", children }: FrameProps) {
     <section
       id={id}
       aria-labelledby={`${id}-h`}
-      className={`relative flex min-h-[100svh] scroll-mt-0 flex-col ${TONE_CLASS[tone]} ${className}`}
+      className={`relative flex min-h-[min(100svh,54rem)] scroll-mt-0 flex-col ${TONE_CLASS[tone]} ${className}`}
       style={{
         paddingInline: "var(--frame-gutter)",
         paddingBlock: "var(--frame-pad-y)",

--- a/components/ui/Frame.tsx
+++ b/components/ui/Frame.tsx
@@ -20,8 +20,9 @@ export function Frame({ id, tone, className = "", children }: FrameProps) {
     <section
       id={id}
       aria-labelledby={`${id}-h`}
-      className={`relative flex min-h-[min(100svh,54rem)] scroll-mt-0 flex-col ${TONE_CLASS[tone]} ${className}`}
+      className={`relative flex scroll-mt-0 flex-col ${TONE_CLASS[tone]} ${className}`}
       style={{
+        minHeight: "min(100svh, var(--frame-min-h-cap))",
         paddingInline: "var(--frame-gutter)",
         paddingBlock: "var(--frame-pad-y)",
       }}


### PR DESCRIPTION
## Summary

- **`Frame`**: cap section min-height via a new `--frame-min-h-cap` token (54rem), applied through inline `minHeight: "min(100svh, var(--frame-min-h-cap))"` alongside the existing `--frame-gutter` / `--frame-pad-y` tokens. On 27"+ monitors, sections stop stretching past ~864px and no longer produce the 200+ px empty bands `mt-auto` used to absorb.
- **`Hero` layout**: drop the `live · epoch 00042 · quic / blake3` meta row and replace the content block's `mt-auto` with a fixed `mt-10`, so the h1 sits at a consistent small offset from the section header regardless of viewport height.
- **`Hero` cascade**: restagger the six `rise-*` animations so the h1's three lines land on their own beats (0 → 120 → 180ms) before paragraph / CTAs / figures at 260 / 340 / 420ms. Previously both "anyone can serve" and "priced, not quoted" shared `rise-2` and revealed simultaneously.

## Test plan

- [x] `pnpm dev`, load `/` on a laptop-sized viewport (~800–900px tall): Hero and Close still fill the viewport; middle sections unchanged.
- [x] Resize viewport to ~1400px tall (simulates 27"): no empty band above the Hero h1 or between the Close fleet-status grid and the copyright footer.
- [x] Verify the Hero cascade reveals as six distinct beats on page load — h1 lines no longer animate in as a single clump.
- [x] `pnpm lint` and `pnpm build` pass; Cloudflare Pages preview deploys clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)