### PR TITLE
fix(hero): close gap between nav and section header

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -19,6 +19,10 @@
   --frame-max: 1280px;
   --frame-gutter: clamp(1.5rem, 4vw, 4rem);
   --frame-pad-y: clamp(4rem, 9vw, 7rem);
+  /* Top padding is ~68% of --frame-pad-y: each section's header sits
+     closer to the divider from the previous block, matching the
+     tightened hero. Bottom padding keeps the full --frame-pad-y. */
+  --frame-pad-top: clamp(2.75rem, 6vw, 4.75rem);
   --frame-min-h-cap: 54rem;
 
   /* Type scale: micro and CTA are fixed; body and headlines scale with viewport. */

--- a/app/globals.css
+++ b/app/globals.css
@@ -20,8 +20,8 @@
   --frame-gutter: clamp(1.5rem, 4vw, 4rem);
   /* Symmetric top/bottom section padding — sections size to their
      content and this sets the breathing room at each end. */
-  --frame-pad-top: clamp(2.5rem, 5vw, 4rem);
-  --frame-pad-y: clamp(2.5rem, 5vw, 4rem);
+  --frame-pad-top: clamp(2.75rem, 5.5vw, 4.5rem);
+  --frame-pad-y: clamp(2.75rem, 5.5vw, 4.5rem);
 
   /* Type scale: micro and CTA are fixed; body and headlines scale with viewport. */
   --fs-micro: 0.6875rem;

--- a/app/globals.css
+++ b/app/globals.css
@@ -18,12 +18,10 @@
   /* Shared content rail: every Frame centers within --frame-max. */
   --frame-max: 1280px;
   --frame-gutter: clamp(1.5rem, 4vw, 4rem);
-  --frame-pad-y: clamp(4rem, 9vw, 7rem);
-  /* Top padding is ~68% of --frame-pad-y: each section's header sits
-     closer to the divider from the previous block, matching the
-     tightened hero. Bottom padding keeps the full --frame-pad-y. */
-  --frame-pad-top: clamp(2.75rem, 6vw, 4.75rem);
-  --frame-min-h-cap: 54rem;
+  /* Symmetric top/bottom section padding — sections size to their
+     content and this sets the breathing room at each end. */
+  --frame-pad-top: clamp(2.5rem, 5vw, 4rem);
+  --frame-pad-y: clamp(2.5rem, 5vw, 4rem);
 
   /* Type scale: micro and CTA are fixed; body and headlines scale with viewport. */
   --fs-micro: 0.6875rem;

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,6 +4,9 @@
   --ink: #000000;
   --paper: #ffffff;
   --whisper: #0f9d6a;
+  /* Visual height of the fixed Chrome nav — used by the first section
+     to sit flush under the bar instead of inheriting --frame-pad-y. */
+  --nav-h: 3.75rem;
 }
 
 @theme inline {

--- a/components/site/Comparison.tsx
+++ b/components/site/Comparison.tsx
@@ -28,7 +28,7 @@ export function Comparison() {
             ["--reveal-delay" as string]: "120ms",
             fontSize: "var(--fs-body)",
           }}
-          className="max-w-[62ch] leading-[1.7] text-paper/75"
+          className="mt-6 max-w-[62ch] leading-[1.7] text-paper/75"
         >
           the pattern repeats whenever something big ships: mirrors fork, cdns
           rate-limit, small teams burn tens of thousands hosting bytes they
@@ -37,7 +37,7 @@ export function Comparison() {
         </p>
       </div>
 
-      <div className="mt-auto flex flex-col pt-12">
+      <div className="mt-auto flex flex-col pt-20">
         <div
           data-reveal
           style={{ ["--reveal-delay" as string]: "260ms" }}

--- a/components/site/Faq.tsx
+++ b/components/site/Faq.tsx
@@ -17,7 +17,7 @@ export function Faq() {
           frequently asked.
         </h2>
 
-        <dl className="flex flex-col divide-y divide-current/20">
+        <dl className="mt-6 flex flex-col divide-y divide-current/20">
           <FaqItem
             delay={0}
             q="How is it 90% cheaper?"

--- a/components/site/Hero.tsx
+++ b/components/site/Hero.tsx
@@ -34,7 +34,7 @@ export function Hero() {
           <span className="rise rise-2 pl-[8vw]">priced, not quoted.</span>
         </h1>
 
-        <div className="grid gap-10 @4xl:grid-cols-[minmax(0,1fr)_minmax(0,440px)] @4xl:items-end @4xl:gap-12">
+        <div className="mt-6 grid gap-10 @4xl:grid-cols-[minmax(0,1fr)_minmax(0,440px)] @4xl:items-end @4xl:gap-12">
           <div className="flex flex-col gap-8 @4xl:gap-12">
             <p
               className="rise rise-3 max-w-[64ch] leading-[1.65]"

--- a/components/site/Hero.tsx
+++ b/components/site/Hero.tsx
@@ -6,7 +6,12 @@ import { HeroTerminal } from "@/components/site/HeroTerminal";
 
 export function Hero() {
   return (
-    <Frame id="intro" tone="paper" className="overflow-hidden">
+    <Frame
+      id="intro"
+      tone="paper"
+      paddingTop="calc(var(--nav-h) + 1rem)"
+      className="overflow-hidden"
+    >
       <SectionHeader
         index="01"
         label="Hero"

--- a/components/site/Method.tsx
+++ b/components/site/Method.tsx
@@ -37,7 +37,7 @@ export function Method() {
         />
       </div>
 
-      <div data-reveal className="mt-auto pt-12">
+      <div data-reveal className="mt-auto pt-20">
         <span className="meta mb-3 block opacity-60">stack</span>
         <div
           className="hug flex flex-wrap items-baseline gap-x-5 gap-y-2 font-semibold tracking-[-0.03em]"

--- a/components/ui/Frame.tsx
+++ b/components/ui/Frame.tsx
@@ -7,9 +7,9 @@ type FrameProps = {
   tone: Tone;
   /** Extra classes on the outer <section>. */
   className?: string;
-  /** Override the section's top padding (default: var(--frame-pad-y)).
+  /** Override the section's top padding (default: var(--frame-pad-top)).
       The first section passes a tighter value so it sits just below the
-      fixed Chrome nav instead of leaving a full frame-pad gap above. */
+      fixed Chrome nav instead of leaving a --frame-pad-top gap above. */
   paddingTop?: string;
   children: ReactNode;
 };
@@ -29,7 +29,8 @@ export function Frame({
   const style: CSSProperties = {
     minHeight: "min(100svh, var(--frame-min-h-cap))",
     paddingInline: "var(--frame-gutter)",
-    paddingBlock: "var(--frame-pad-y)",
+    paddingTop: "var(--frame-pad-top)",
+    paddingBottom: "var(--frame-pad-y)",
   };
   if (paddingTop !== undefined) {
     style.paddingTop = paddingTop;

--- a/components/ui/Frame.tsx
+++ b/components/ui/Frame.tsx
@@ -27,7 +27,6 @@ export function Frame({
   children,
 }: FrameProps) {
   const style: CSSProperties = {
-    minHeight: "min(100svh, var(--frame-min-h-cap))",
     paddingInline: "var(--frame-gutter)",
     paddingTop: "var(--frame-pad-top)",
     paddingBottom: "var(--frame-pad-y)",

--- a/components/ui/Frame.tsx
+++ b/components/ui/Frame.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import type { CSSProperties, ReactNode } from "react";
 
 type Tone = "ink" | "paper";
 
@@ -7,6 +7,10 @@ type FrameProps = {
   tone: Tone;
   /** Extra classes on the outer <section>. */
   className?: string;
+  /** Override the section's top padding (default: var(--frame-pad-y)).
+      The first section passes a tighter value so it sits just below the
+      fixed Chrome nav instead of leaving a full frame-pad gap above. */
+  paddingTop?: string;
   children: ReactNode;
 };
 
@@ -15,17 +19,28 @@ const TONE_CLASS: Record<Tone, string> = {
   paper: "bg-[var(--paper)] text-[var(--ink)]",
 };
 
-export function Frame({ id, tone, className = "", children }: FrameProps) {
+export function Frame({
+  id,
+  tone,
+  className = "",
+  paddingTop,
+  children,
+}: FrameProps) {
+  const style: CSSProperties = {
+    minHeight: "min(100svh, var(--frame-min-h-cap))",
+    paddingInline: "var(--frame-gutter)",
+    paddingBlock: "var(--frame-pad-y)",
+  };
+  if (paddingTop !== undefined) {
+    style.paddingTop = paddingTop;
+  }
+
   return (
     <section
       id={id}
       aria-labelledby={`${id}-h`}
       className={`relative flex scroll-mt-0 flex-col ${TONE_CLASS[tone]} ${className}`}
-      style={{
-        minHeight: "min(100svh, var(--frame-min-h-cap))",
-        paddingInline: "var(--frame-gutter)",
-        paddingBlock: "var(--frame-pad-y)",
-      }}
+      style={style}
     >
       <div
         className="@container relative z-10 mx-auto flex w-full flex-1 flex-col"


### PR DESCRIPTION
## Summary
- Introduce `--nav-h` (3.75rem) — visual height of the fixed Chrome nav.
- Add optional `paddingTop` prop to `Frame`; Hero passes `calc(var(--nav-h) + 1rem)` so the section sits flush under the nav.
- Drop the `--frame-min-h-cap` floor and the `minHeight` inline style so every section sizes to its own content instead of stretching to 54rem on tall viewports.
- Unify `--frame-pad-top` and `--frame-pad-y` at `clamp(2.75rem, 5.5vw, 4.5rem)` — symmetric, tighter breathing room at each end.
- Nudge inner content down one line inside each section: `mt-6` on Hero's body/terminal grid, Comparison's lead paragraph, and FAQ's `<dl>`; `pt-20` on Comparison's table and Method's stack.

## Test plan
- [ ] `pnpm dev` — on a ≥ 900px-tall viewport, the Hero sits flush under the fixed nav; each section sizes to its content with a modest gap above/below.
- [ ] Resize to ~375×700 (mobile) — layout packs naturally; no overlap between nav and section divider.
- [ ] `pnpm lint` and `pnpm build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)