### PR TITLE
feat(theme): swap accent from emerald to blush pink

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,7 +1,7 @@
 @import "tailwindcss";
 
 :root {
-  --ink: #1d1d1f;
+  --ink: #000000;
   --paper: #ffffff;
   --whisper: #ebd0d0;
   /* Visual height of the fixed Chrome nav. Frame uses it as scroll-margin

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,7 +1,7 @@
 @import "tailwindcss";
 
 :root {
-  --ink: #0f1f35;
+  --ink: #1d1d1f;
   --paper: #ffffff;
   --whisper: #ebd0d0;
   /* Visual height of the fixed Chrome nav. Frame uses it as scroll-margin

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,9 +1,9 @@
 @import "tailwindcss";
 
 :root {
-  --ink: #000000;
+  --ink: #0f1f35;
   --paper: #ffffff;
-  --whisper: #0f9d6a;
+  --whisper: #ebd0d0;
   /* Visual height of the fixed Chrome nav. Frame uses it as scroll-margin
      so anchor jumps don't land with the section header clipped. */
   --nav-h: 3rem;


### PR DESCRIPTION
## Summary

- Replaces the emerald `#0f9d6a` accent with **blush pink `#EBD0D0`**.
- Page background stays pure black (`--ink: #000000`); only `--whisper` actually changes from the original codebase.
- Single touch point: one value in `:root` of `app/globals.css`. Every brand surface (selection, terminal accents, fleet pulses, nav underline, inline `deCDN` highlights) cascades through `--whisper`, so no component edits are needed.
- Black-on-pink selection contrast stays at AAA.

> Branch name `theme/navy-blush-palette` and the commit history reflect a few iterations through navy and Apple-black before settling back on pure black.

## Known caveat

The hero terminal has a white (`--paper`) background and uses `--whisper` for prompt `$`, arrows, and "ok" glyphs (`globals.css:343`). Pale pink on white is low-contrast (~1.2:1) and will look washed out there. Two follow-up options if needed:
1. Override `.prompt`, `.arrow`, `.ok` inside the terminal to use `var(--ink)`.
2. Choose a deeper accent that reads on both black and white.

## Test plan

- [ ] `pnpm dev` and load `http://localhost:3000`
- [ ] Hero: dot after headline + inline "deCDN" highlight render blush pink on black
- [ ] Drag-select body copy → pink selection bg with black text, fully readable
- [ ] Fleet section: live pulse + glow render pink against black
- [ ] Nav: hover/scroll sections, active underline reads pink
- [ ] Terminal: confirm whether the pink prompt/arrow/ok glyphs on white need the override above
- [ ] `pnpm build` produces the static export under `out/` cleanly (already verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)