### PR TITLE
feat(ui): enlarge nav wordmark, soften h1/h2, deepen hero cascade

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -6,10 +6,11 @@
   --whisper: #0f9d6a;
   /* Intentionally 0: anchor jumps land flush at viewport top (under
      the fixed nav). Section headers don't get clipped because every
-     Frame's --frame-pad-y is already large enough to clear the nav
-     on its own. The variable still exists so a future non-zero
-     override (taller nav, sticky banner) can restore an offset
-     without touching every Frame call site. */
+     Frame's --frame-pad-y floor (5rem = 80px) matches the current
+     fixed-nav height (py-6 + 32px wordmark ≈ 80px). If the nav grows
+     again, raise the --frame-pad-y floor in lockstep — or set
+     --nav-h to the measured nav height and add scroll-mt-[var(--nav-h)]
+     on each Frame so the two stay decoupled. */
   --nav-h: 0;
 }
 
@@ -22,7 +23,7 @@
   /* Shared content rail: every Frame centers within --frame-max. */
   --frame-max: 1280px;
   --frame-gutter: clamp(1.5rem, 4vw, 4rem);
-  --frame-pad-y: clamp(4rem, 9vw, 7rem);
+  --frame-pad-y: clamp(5rem, 9vw, 7rem);
   --frame-min-h-cap: 54rem;
 
   /* Type scale: micro and CTA are fixed; body and headlines scale with viewport. */

--- a/app/globals.css
+++ b/app/globals.css
@@ -9,9 +9,11 @@
      Frame's --frame-pad-y floor (5rem = 80px) sits comfortably above
      the current fixed-nav height (py-5 + 30px wordmark ≈ 70px),
      leaving ~10px of breathing room below the nav. If the nav grows
-     past 5rem, raise the --frame-pad-y floor in lockstep — or set
-     --nav-h to the measured nav height and add scroll-mt-[var(--nav-h)]
-     on each Frame so the two stay decoupled. */
+     past 5rem, switch to the decoupled path: set --nav-h to the
+     measured nav height and apply scroll-mt-[var(--nav-h)] on each
+     Frame. (Bumping the 5rem floor on --frame-pad-y only helps below
+     ~889px — above that the clamp's 9vw term already exceeds 5rem,
+     so a bigger floor does nothing on desktop.) */
   --nav-h: 0;
 }
 
@@ -24,7 +26,11 @@
   /* Shared content rail: every Frame centers within --frame-max. */
   --frame-max: 1280px;
   --frame-gutter: clamp(1.5rem, 4vw, 4rem);
-  --frame-pad-y: clamp(5rem, 9vw, 7rem);
+  --frame-pad-y: clamp(
+    5rem,
+    9vw,
+    7rem
+  ); /* floor coupled to nav height — see --nav-h note above */
   --frame-min-h-cap: 54rem;
 
   /* Type scale: micro and CTA are fixed; body and headlines scale with viewport. */
@@ -707,9 +713,7 @@ a.underline-brutal:hover .arrow {
     color 300ms cubic-bezier(0.2, 0.8, 0.2, 1);
 }
 
-/* Scoped bump: nav typography reads a hair larger than the shared
-   .meta / .nav-label defaults used elsewhere on the page. Keeping the
-   override local avoids growing every section header and stat label. */
+/* Scoped to .chrome-nav so the bump doesn't ripple to every section header / stat label. */
 .chrome-nav .meta,
 .chrome-nav .nav-item .nav-label {
   font-size: 12px;

--- a/app/globals.css
+++ b/app/globals.css
@@ -31,9 +31,9 @@
   --fs-body: clamp(0.9375rem, 0.55vw + 0.78rem, 1.0625rem);
   --fs-lead: clamp(1rem, 0.6vw + 0.82rem, 1.125rem);
   --fs-h3: clamp(1.375rem, 4vw, 3.5rem);
-  --fs-h2: clamp(2.125rem, 7vw, 6.5rem);
+  --fs-h2: clamp(1.875rem, 5.8vw, 5.25rem);
   --fs-method-row: clamp(2rem, 6.5vw, 6rem);
-  --fs-h1: clamp(2.5rem, 8.4vw, 7.75rem);
+  --fs-h1: clamp(2.25rem, 7vw, 6.5rem);
   --fs-display: clamp(3.5rem, 14vw, 12.5rem);
   --fs-price: clamp(1.125rem, 5vw, 4rem);
 }
@@ -703,6 +703,14 @@ a.underline-brutal:hover .arrow {
     -webkit-backdrop-filter 260ms cubic-bezier(0.2, 0.8, 0.2, 1),
     border-bottom-color 260ms cubic-bezier(0.2, 0.8, 0.2, 1),
     color 300ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+/* Scoped bump: nav typography reads a hair larger than the shared
+   .meta / .nav-label defaults used elsewhere on the page. Keeping the
+   override local avoids growing every section header and stat label. */
+.chrome-nav .meta,
+.chrome-nav .nav-item .nav-label {
+  font-size: 12px;
 }
 
 .chrome-nav[data-scrolled="true"] {

--- a/app/globals.css
+++ b/app/globals.css
@@ -9,11 +9,12 @@
      Frame's --frame-pad-y floor (5rem = 80px) sits comfortably above
      the current fixed-nav height (py-5 + 30px wordmark ≈ 70px),
      leaving ~10px of breathing room below the nav. If the nav grows
-     past 5rem, switch to the decoupled path: set --nav-h to the
-     measured nav height and apply scroll-mt-[var(--nav-h)] on each
-     Frame. (Bumping the 5rem floor on --frame-pad-y only helps below
-     ~889px — above that the clamp's 9vw term already exceeds 5rem,
-     so a bigger floor does nothing on desktop.) */
+     past 5rem, set --nav-h to the measured nav height — Frame already
+     applies scroll-mt-[var(--nav-h)] on every section, so anchor
+     offsets pick it up automatically. (Bumping the 5rem floor on
+     --frame-pad-y only helps below ~889px — above that the clamp's
+     9vw term already exceeds 5rem, so a bigger floor does nothing on
+     desktop.) */
   --nav-h: 0;
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -6,9 +6,10 @@
   --whisper: #0f9d6a;
   /* Intentionally 0: anchor jumps land flush at viewport top (under
      the fixed nav). Section headers don't get clipped because every
-     Frame's --frame-pad-y floor (5rem = 80px) matches the current
-     fixed-nav height (py-6 + 32px wordmark ≈ 80px). If the nav grows
-     again, raise the --frame-pad-y floor in lockstep — or set
+     Frame's --frame-pad-y floor (5rem = 80px) sits comfortably above
+     the current fixed-nav height (py-5 + 30px wordmark ≈ 70px),
+     leaving ~10px of breathing room below the nav. If the nav grows
+     past 5rem, raise the --frame-pad-y floor in lockstep — or set
      --nav-h to the measured nav height and add scroll-mt-[var(--nav-h)]
      on each Frame so the two stay decoupled. */
   --nav-h: 0;

--- a/components/site/Chrome.tsx
+++ b/components/site/Chrome.tsx
@@ -113,7 +113,7 @@ export function Chrome() {
       aria-label="Primary"
       data-scrolled={scrolled ? "true" : undefined}
       data-tone={onDark ? "ink" : "paper"}
-      className={`chrome-nav fixed inset-x-0 top-0 z-50 py-6 ${
+      className={`chrome-nav fixed inset-x-0 top-0 z-50 py-5 ${
         onDark ? "text-[var(--paper)]" : "text-[var(--ink)]"
       }`}
       style={{ paddingInline: "var(--frame-gutter)" }}
@@ -133,16 +133,16 @@ export function Chrome() {
           <img
             src="/wordmark-light.svg"
             alt="decdn_"
-            width={120}
-            height={32}
+            width={112}
+            height={30}
             className={onDark ? "hidden" : "block"}
           />
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src="/wordmark-dark.svg"
             alt="decdn_"
-            width={120}
-            height={32}
+            width={112}
+            height={30}
             className={onDark ? "block" : "hidden"}
           />
           <span className="meta hidden opacity-70 sm:inline">

--- a/components/site/Chrome.tsx
+++ b/components/site/Chrome.tsx
@@ -145,9 +145,7 @@ export function Chrome() {
             height={30}
             className={onDark ? "block" : "hidden"}
           />
-          <span className="meta hidden opacity-70 sm:inline">
-            labs · mmxxvi
-          </span>
+          <span className="meta hidden opacity-70 sm:inline">labs</span>
         </a>
 
         <ul className="col-start-2 hidden items-center gap-7 justify-self-center md:flex">

--- a/components/site/Chrome.tsx
+++ b/components/site/Chrome.tsx
@@ -124,7 +124,7 @@ export function Chrome() {
       >
         <a
           href="#intro"
-          className="col-start-1 flex items-center gap-3 justify-self-start no-underline"
+          className="col-start-1 flex items-center gap-3 no-underline"
         >
           {/* Both variants stay mounted and toggled via `display` so the
               tone flip never flashes — browsers fetch hidden <img> tags
@@ -148,7 +148,7 @@ export function Chrome() {
           <span className="meta hidden opacity-70 sm:inline">labs</span>
         </a>
 
-        <ul className="col-start-2 hidden items-center gap-7 justify-self-center md:flex">
+        <ul className="hidden items-center gap-7 md:flex">
           {NAV.map((item) => {
             const isActive = active === item.id;
             return (

--- a/components/site/Chrome.tsx
+++ b/components/site/Chrome.tsx
@@ -113,16 +113,19 @@ export function Chrome() {
       aria-label="Primary"
       data-scrolled={scrolled ? "true" : undefined}
       data-tone={onDark ? "ink" : "paper"}
-      className={`chrome-nav fixed inset-x-0 top-0 z-50 py-5 ${
+      className={`chrome-nav fixed inset-x-0 top-0 z-50 py-6 ${
         onDark ? "text-[var(--paper)]" : "text-[var(--ink)]"
       }`}
       style={{ paddingInline: "var(--frame-gutter)" }}
     >
       <div
-        className="mx-auto flex w-full items-center justify-between gap-4"
+        className="mx-auto grid w-full grid-cols-[1fr_auto_1fr] items-center gap-4"
         style={{ maxWidth: "var(--frame-max)" }}
       >
-        <a href="#intro" className="flex items-center gap-3 no-underline">
+        <a
+          href="#intro"
+          className="col-start-1 flex items-center gap-3 justify-self-start no-underline"
+        >
           {/* Both variants stay mounted and toggled via `display` so the
               tone flip never flashes — browsers fetch hidden <img> tags
               eagerly enough that the swap-in variant is already in cache. */}
@@ -130,16 +133,16 @@ export function Chrome() {
           <img
             src="/wordmark-light.svg"
             alt="decdn_"
-            width={56}
-            height={15}
+            width={120}
+            height={32}
             className={onDark ? "hidden" : "block"}
           />
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src="/wordmark-dark.svg"
             alt="decdn_"
-            width={56}
-            height={15}
+            width={120}
+            height={32}
             className={onDark ? "block" : "hidden"}
           />
           <span className="meta hidden opacity-70 sm:inline">
@@ -147,7 +150,7 @@ export function Chrome() {
           </span>
         </a>
 
-        <ul className="hidden items-center gap-7 md:flex">
+        <ul className="col-start-2 hidden items-center gap-7 justify-self-center md:flex">
           {NAV.map((item) => {
             const isActive = active === item.id;
             return (
@@ -165,7 +168,7 @@ export function Chrome() {
           })}
         </ul>
 
-        <div className="flex items-center gap-5">
+        <div className="col-start-3 flex items-center gap-5 justify-self-end">
           <a
             href={links.docs}
             className="meta flex items-center gap-2 no-underline"

--- a/components/site/Close.tsx
+++ b/components/site/Close.tsx
@@ -90,10 +90,8 @@ export function Close() {
           className="grid grid-cols-1 gap-2 tracking-[0.2em] uppercase opacity-80 @md:grid-cols-3 @md:items-center"
           style={{ fontSize: "var(--fs-micro)" }}
         >
-          <span>© mmxxvi · decdn labs</span>
-          <span className="@md:text-center">
-            built in rust · rendered in geist
-          </span>
+          <span>© decdn labs · open source</span>
+          <span className="@md:text-center">probably over-engineered</span>
           <span className="tabular-nums @md:text-right">node-001 / v0</span>
         </div>
       </footer>

--- a/components/site/Close.tsx
+++ b/components/site/Close.tsx
@@ -92,7 +92,7 @@ export function Close() {
         >
           <span>© decdn labs · open source</span>
           <span className="@md:text-center">
-            built in rust · over-engineered, deliberately
+            built in rust · probably over-engineered
           </span>
           <span className="tabular-nums @md:text-right">node-001 / v0</span>
         </div>

--- a/components/site/Close.tsx
+++ b/components/site/Close.tsx
@@ -94,7 +94,7 @@ export function Close() {
           <span className="@md:text-center">
             built in rust · rendered in geist
           </span>
-          <span className="tabular-nums @md:text-right">node-001 / v0.0.0</span>
+          <span className="tabular-nums @md:text-right">node-001 / v0</span>
         </div>
       </footer>
     </Frame>

--- a/components/site/Close.tsx
+++ b/components/site/Close.tsx
@@ -91,7 +91,9 @@ export function Close() {
           style={{ fontSize: "var(--fs-micro)" }}
         >
           <span>© decdn labs · open source</span>
-          <span className="@md:text-center">probably over-engineered</span>
+          <span className="@md:text-center">
+            built in rust · over-engineered, deliberately
+          </span>
           <span className="tabular-nums @md:text-right">node-001 / v0</span>
         </div>
       </footer>

--- a/components/site/FleetStatus.tsx
+++ b/components/site/FleetStatus.tsx
@@ -24,7 +24,7 @@ export function FleetStatus({ className }: { className?: string }) {
           <span className="fleet-dot" />
           <span className="fleet-dot" />
           <span className="fleet-dot" />
-          <span className="fleet-head-label">decdn · fleet · live</span>
+          <span className="fleet-head-label">decdn · fleet · test</span>
         </div>
 
         <div className="fleet-body">

--- a/components/site/Hero.tsx
+++ b/components/site/Hero.tsx
@@ -20,13 +20,13 @@ export function Hero() {
           style={{ fontSize: "var(--fs-h1)" }}
         >
           <span className="rise rise-1">the delivery layer</span>
-          <span className="rise rise-2 pl-[4vw]">
+          <span className="rise rise-2 pl-[7vw]">
             anyone can serve
             <span aria-hidden style={{ color: "var(--whisper)" }}>
               .
             </span>
           </span>
-          <span className="rise rise-2 pl-[8vw]">priced, not quoted.</span>
+          <span className="rise rise-2 pl-[12vw]">priced, not quoted.</span>
         </h1>
 
         <div className="grid gap-10 @4xl:grid-cols-[minmax(0,1fr)_minmax(0,440px)] @4xl:items-end @4xl:gap-12">

--- a/components/site/Hero.tsx
+++ b/components/site/Hero.tsx
@@ -10,7 +10,7 @@ export function Hero() {
       <SectionHeader
         index="01"
         label="Hero"
-        timestamp="2026-04 · devnet v0.0.0"
+        timestamp="2026-04 · testnet · v0"
       />
 
       <div className="mt-10 flex flex-col gap-8 @4xl:gap-12">


### PR DESCRIPTION
## Summary

- **Navbar:** wordmark `56×15` → `112×30` (both light/dark variants), bar at `py-5`, scoped `.meta` / `.nav-label` bump from 11px → 12px (only inside `.chrome-nav` so shared section-header / stat-label / terminal-label typography elsewhere stays the same), and the `labs · mmxxvi` colophon trimmed to just `labs` (drops the roman numeral).
- **Mobile layout fix:** the inner row is now `grid-cols-[1fr_auto_1fr]` with explicit `col-start-1` on the wordmark and `col-start-3` on the docs/litepaper cluster. Without explicit placement, when the middle `<ul>` was `display: none` below `md`, CSS Grid auto-placement assigned the docs/litepaper `<div>` to column 2 — `justify-self-end` then pinned it to the right edge of column 2 (≈ center of the bar). Pinning to col 3 keeps it on the right at every viewport.
- **Type scale:** `--fs-h1` max cap `7.75rem` → `6.5rem`, `--fs-h2` `6.5rem` → `5.25rem`. Hero ("the delivery layer / anyone can serve / priced, not quoted."), Comparison ("information scaled. / supply didn't."), and FAQ ("questions, …") read less shouty on wide viewports while staying clearly above body.
- **Hero cascade:** indents iterated and settled at `pl-[7vw]` (line 2) and `pl-[12vw]` (line 3) — steeper diagonal under the new tighter h1.
- **Anchor-clip fix (review):** `--frame-pad-y` floor `4rem` → `5rem` (80px). The taller nav was clipping the §0X `SectionHeader` strip on viewports ≤~889px where `9vw < 5rem`. The first attempt matched nav height exactly (0px clearance — still read as clipped); the follow-up trims `py-6` → `py-5` and wordmark `120×32` → `112×30` so the bar sits at ~70px and the 80px floor now leaves ~10px of real breathing room under the nav. Comment in `globals.css` documents the coupling and explicitly notes that future nav growth past 5rem should set `--nav-h` to the measured nav height — `Frame` already applies `scroll-mt-[var(--nav-h)]` on every section, and bumping the floor would be a no-op above ~889px since the clamp's 9vw term dominates there.
- **Copy rebrand:** `devnet v0.0.0` / `node-001 / v0.0.0` / `decdn · fleet · live` → `testnet · v0` / `node-001 / v0` / `decdn · fleet · test` across Hero, Close, and FleetStatus. Pre-mainnet honesty pass.
- **Footer micro-strip:** `© mmxxvi · decdn labs` → `© decdn labs · open source` (left); `built in rust · rendered in geist` → `built in rust · probably over-engineered` (center); right column (`node-001 / v0`) unchanged. Keeps the stack-pride prefix, swaps the Geist namedrop for a self-aware hedge.
- **Self-review polish:** dropped redundant `col-start-2` / `justify-self-center` on the centered `<ul>` (auto-placement lands it in col 2 by definition once cols 1 and 3 are pinned; the auto column sizes to content so `justify-self` is moot) and redundant `justify-self-start` on the wordmark `<a>` (a stretched flex container left-aligns identically). Kept `justify-self-end` on the docs/litepaper `<div>` — it is load-bearing. Tightened the `.chrome-nav .meta` comment from 3 lines to 1; added a one-line cross-reference at `--frame-pad-y` so the coupling is discoverable from either side.

## Review notes

- **gemini-code-assist (HIGH) + Copilot — anchor clip / nav obscuring section content:** addressed across `4ff6a12` (raise floor) + `577211c` (trim nav so the floor actually creates visible clearance, not just exact equality).
- **Copilot — `--nav-h` comment told future-us to add `scroll-mt-[var(--nav-h)]` even though `Frame.tsx:23` already applies it:** addressed in `1d1227e`. Wording now says "set `--nav-h` — Frame already applies the scroll-mt", so future-us doesn't go duplicate the utility at call sites.
- **gemini-code-assist (MEDIUM) — convert new `font-size: 12px` to `0.75rem`:** declined for this PR; tracked in #36 as a coordinated px → rem sweep across every label-tier rule. One-off conversion would produce visual asymmetry under user font scaling, see the inline reply.
- **gemini sub-suggestion — `motion-safe:scroll-smooth`:** no smooth scroll exists today, nothing to gate.

## Test plan

- [ ] `pnpm dev` → http://localhost:3000
- [ ] Wordmark visibly larger than the original 56×15; bar at `py-5` height; nav links centered relative to `--frame-max` rail at desktop widths.
- [ ] Navbar suffix reads `LABS` (no roman numeral); above `sm` only.
- [ ] Resize 1920 → 1280 → 800px: centered nav (`compare · method · faq · contact`) does NOT drift right as the logo column widens.
- [ ] Resize below `md` (≤768px): docs/litepaper links sit at the right edge of the bar.
- [ ] Resize ≤~889px (where the floor kicks in): §01 / Hero strip is clearly visible *with a gap* below the navbar (~10px). Same after clicking `#compare`, `#method`, `#faq`, `#contact`.
- [ ] Scroll past hero into compare/faq: tone flip still triggers at the section boundary.
- [ ] Hero h1 cascade: "anyone can serve." sits a bit right of "the delivery layer", "priced, not quoted." sits further right still.
- [ ] Hero §01 strip top-right reads `2026-04 · TESTNET · V0`; FleetStatus panel head reads `DECDN · FLEET · TEST`.
- [ ] Close section footer micro-strip reads `© DECDN LABS · OPEN SOURCE` / `BUILT IN RUST · PROBABLY OVER-ENGINEERED` / `node-001 / v0` across the three columns.
- [ ] Section headings on Compare and FAQ visibly smaller than before but still bigger than body.
- [ ] `pnpm lint` clean; `pnpm exec tsc --noEmit` clean; `pnpm build` static export still produces `out/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)