### PR TITLE
fix(links): point Run a Node CTA at live docs URL

### DIFF
--- a/lib/links.ts
+++ b/lib/links.ts
@@ -4,7 +4,7 @@ export const links = {
   x: "https://x.com/deCDNorg",
   litepaper: "/litepaper-v2.pdf",
   docs: "https://docs.decdn.org/overview/introduction",
-  runNode: "https://docs.decdn.org/node-operators/overview",
+  runNode: "https://docs.decdn.org/overview/introduction",
   contact: "mailto:info@decdn.org",
 } as const;
 


### PR DESCRIPTION
## Summary
- Swap `links.runNode` from the 404ing `/node-operators/overview` to `/overview/introduction` so both "Run a node" CTAs (Hero + Close) land on a live docs page.
- Single source of truth in `lib/links.ts`; no component changes needed.

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm build` produces static export with no errors
- [x] Click "Run a node" in hero — opens https://docs.decdn.org/overview/introduction (no 404)
- [x] Click "Run a node" in closing section — same destination

🤖 Generated with [Claude Code](https://claude.com/claude-code)