### PR TITLE
fix(links): rename "run a node" CTA to "read the docs"

### DIFF
--- a/components/site/Close.tsx
+++ b/components/site/Close.tsx
@@ -61,9 +61,9 @@ export function Close() {
             <a
               className="underline-brutal font-semibold tracking-[0.02em]"
               style={{ fontSize: "var(--fs-lead)" }}
-              href={links.runNode}
+              href={links.docs}
             >
-              run a node
+              read the docs
               <span className="arrow" aria-hidden>
                 →
               </span>

--- a/components/site/Hero.tsx
+++ b/components/site/Hero.tsx
@@ -63,9 +63,9 @@ export function Hero() {
               <a
                 className="underline-brutal font-semibold tracking-[0.14em] uppercase"
                 style={{ fontSize: "var(--fs-cta)" }}
-                href={links.runNode}
+                href={links.docs}
               >
-                run a node
+                read the docs
                 <span className="arrow" aria-hidden>
                   →
                 </span>

--- a/lib/links.ts
+++ b/lib/links.ts
@@ -4,7 +4,6 @@ export const links = {
   x: "https://x.com/deCDNorg",
   litepaper: "/litepaper-v2.pdf",
   docs: "https://docs.decdn.org/overview/introduction",
-  runNode: "https://docs.decdn.org/overview/introduction",
   contact: "mailto:info@decdn.org",
 } as const;
 


### PR DESCRIPTION
## Summary
- Rename the Hero and Close CTA text from "run a node" to "read the docs" (both already linked to the docs URL).
- Switch `href` from `links.runNode` to `links.docs` and drop the now-unused `runNode` entry from `lib/links.ts`.

## Test plan
- [x] `pnpm lint` clean
- [ ] Verify the Hero (`#intro`) and Contact (`#contact`) CTAs render as "read the docs →" and link to `https://docs.decdn.org/overview/introduction`


---
_Generated by [Claude Code](https://claude.ai/code/session_01HXP8H7XyeXh6KBj5MkwCrS)_