### PR TITLE
feat: hero CTA polish + sitemap index for docs

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -121,7 +121,7 @@ body {
 @keyframes brutal-rise {
   from {
     opacity: 0;
-    transform: translateY(18px);
+    transform: translateY(28px);
   }
   to {
     opacity: 1;
@@ -131,26 +131,26 @@ body {
 
 .rise {
   opacity: 0;
-  animation: brutal-rise 700ms cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+  animation: brutal-rise 850ms cubic-bezier(0.16, 1, 0.3, 1) forwards;
 }
 
 .rise-0 {
   animation-delay: 0ms;
 }
 .rise-1 {
-  animation-delay: 120ms;
+  animation-delay: 80ms;
 }
 .rise-2 {
-  animation-delay: 180ms;
+  animation-delay: 200ms;
 }
 .rise-3 {
-  animation-delay: 260ms;
+  animation-delay: 320ms;
 }
 .rise-4 {
-  animation-delay: 340ms;
+  animation-delay: 460ms;
 }
 .rise-5 {
-  animation-delay: 420ms;
+  animation-delay: 600ms;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -234,19 +234,20 @@ a.underline-brutal {
   text-decoration: none;
   padding-bottom: 2px;
   border-bottom: 1px solid currentColor;
-  transition: letter-spacing 220ms ease;
+  transition: border-bottom-color 260ms cubic-bezier(0.2, 0.8, 0.2, 1);
 }
 
 a.underline-brutal:hover {
-  letter-spacing: 0.02em;
+  border-bottom-color: var(--whisper);
 }
 
 a.underline-brutal .arrow {
-  transition: transform 220ms cubic-bezier(0.2, 0.8, 0.2, 1);
+  transition: transform 260ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 a.underline-brutal:hover .arrow {
-  transform: translateX(4px);
+  transform: translateX(6px);
+  color: var(--whisper);
 }
 
 /* --- hero terminal -----------------------------------------------------

--- a/app/globals.css
+++ b/app/globals.css
@@ -242,7 +242,9 @@ a.underline-brutal:hover {
 }
 
 a.underline-brutal .arrow {
-  transition: transform 260ms cubic-bezier(0.16, 1, 0.3, 1);
+  transition:
+    transform 260ms cubic-bezier(0.16, 1, 0.3, 1),
+    color 260ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 a.underline-brutal:hover .arrow {

--- a/app/sitemap-pages.xml/route.ts
+++ b/app/sitemap-pages.xml/route.ts
@@ -4,8 +4,6 @@ import { SITE_URL } from "@/lib/links";
 // static files at build time. GET-only is the only verb supported in export.
 export const dynamic = "force-static";
 
-// Marketing-site URLs. Add a new <url> entry here when shipping a new page;
-// the sibling `sitemap.xml` route serves the index that references this file.
 const BODY = `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url><loc>${SITE_URL}</loc></url>

--- a/app/sitemap-pages.xml/route.ts
+++ b/app/sitemap-pages.xml/route.ts
@@ -1,0 +1,19 @@
+import { SITE_URL } from "@/lib/links";
+
+// Required by Next 16 under `output: "export"` for route handlers that emit
+// static files at build time. GET-only is the only verb supported in export.
+export const dynamic = "force-static";
+
+// Marketing-site URLs. Add a new <url> entry here when shipping a new page;
+// the sibling `sitemap.xml` route serves the index that references this file.
+const BODY = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>${SITE_URL}</loc></url>
+</urlset>
+`;
+
+export function GET() {
+  return new Response(BODY, {
+    headers: { "Content-Type": "application/xml" },
+  });
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,9 +1,0 @@
-import type { MetadataRoute } from "next";
-import { SITE_URL } from "@/lib/links";
-
-// Required by Next 16 under `output: "export"` for metadata route handlers.
-export const dynamic = "force-static";
-
-export default function sitemap(): MetadataRoute.Sitemap {
-  return [{ url: SITE_URL }];
-}

--- a/app/sitemap.xml/route.ts
+++ b/app/sitemap.xml/route.ts
@@ -1,0 +1,23 @@
+import { SITE_URL, links } from "@/lib/links";
+
+// Required by Next 16 under `output: "export"` for route handlers that emit
+// static files at build time. GET-only is the only verb supported in export.
+export const dynamic = "force-static";
+
+// Sitemap index. Marketing URLs live in `sitemap-pages.xml`; docs are served
+// by Mintlify at `docs.decdn.org/sitemap.xml`. Cross-host entries require
+// both hosts to be verified in Search Console for Google to honor them.
+const DOCS_SITEMAP = `${new URL(links.docs).origin}/sitemap.xml`;
+
+const BODY = `<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap><loc>${SITE_URL}sitemap-pages.xml</loc></sitemap>
+  <sitemap><loc>${DOCS_SITEMAP}</loc></sitemap>
+</sitemapindex>
+`;
+
+export function GET() {
+  return new Response(BODY, {
+    headers: { "Content-Type": "application/xml" },
+  });
+}

--- a/app/sitemap.xml/route.ts
+++ b/app/sitemap.xml/route.ts
@@ -4,9 +4,8 @@ import { SITE_URL, links } from "@/lib/links";
 // static files at build time. GET-only is the only verb supported in export.
 export const dynamic = "force-static";
 
-// Sitemap index. Marketing URLs live in `sitemap-pages.xml`; docs are served
-// by Mintlify at `docs.decdn.org/sitemap.xml`. Cross-host entries require
-// both hosts to be verified in Search Console for Google to honor them.
+// Cross-host sitemap entries are only honored by Google when both hosts are
+// verified in Search Console.
 const DOCS_SITEMAP = `${new URL(links.docs).origin}/sitemap.xml`;
 
 const BODY = `<?xml version="1.0" encoding="UTF-8"?>

--- a/components/site/Hero.tsx
+++ b/components/site/Hero.tsx
@@ -71,7 +71,7 @@ export function Hero() {
                 </span>
               </a>
               <a
-                className="underline-brutal font-semibold tracking-[0.14em] uppercase opacity-55 hover:opacity-100"
+                className="underline-brutal font-semibold tracking-[0.14em] uppercase"
                 style={{ fontSize: "var(--fs-cta)" }}
                 href={links.github}
               >


### PR DESCRIPTION
## Summary
- Hero `source` CTA renders solid ink (drop `opacity-55 hover:opacity-100`) so it sits flush with `read the litepaper` and `run a node`. Closes #45.
- Shared `a.underline-brutal` hover swaps the letter-spacing jiggle (which reflowed adjacent text) for a `var(--whisper)` underline + brighter arrow nudge — no width shift, brand accent picked up.
- `brutal-rise` page-load cascade reworked: 28px translate, 850ms expo-out, restaggered to `0 / 80 / 200 / 320 / 460 / 600` ms so each line lands distinctly.
- Sitemap restructured into a sitemap index at `/sitemap.xml` referencing a marketing-only `/sitemap-pages.xml` and the Mintlify-served `https://docs.decdn.org/sitemap.xml`. Picked option 1 from the issue (sitemap index) over option 2 (inline) because docs already publish their own sitemap and the index pattern auto-tracks new MDX without edits here. Closes #38.

## Test plan
- [x] `pnpm build` — static export succeeds; `out/sitemap.xml` is a well-formed `<sitemapindex>`, `out/sitemap-pages.xml` is a `<urlset>` with the homepage.
- [x] `pnpm lint` — clean.
- [x] Manual: hero entrance reads as deliberate (not laggy); `source` CTA at parity with siblings; hover treatment feels clean (no width jiggle, whisper accent visible).
- [x] Reduced motion: existing `prefers-reduced-motion` block still suppresses `.rise` (no change needed).
- [ ] Operational: verify both `decdn.org` and `docs.decdn.org` in Google Search Console so cross-host sitemap-index entries are honored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)