### PR TITLE
refactor(close): use wordmark-light.svg for brand mark

### DIFF
--- a/components/site/Chrome.tsx
+++ b/components/site/Chrome.tsx
@@ -132,7 +132,7 @@ export function Chrome() {
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src="/wordmark-light.svg"
-            alt="decdn_"
+            alt="decdn"
             width={112}
             height={30}
             className={onDark ? "hidden" : "block"}
@@ -140,7 +140,7 @@ export function Chrome() {
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src="/wordmark-dark.svg"
-            alt="decdn_"
+            alt="decdn"
             width={112}
             height={30}
             className={onDark ? "block" : "hidden"}

--- a/components/site/Close.tsx
+++ b/components/site/Close.tsx
@@ -22,7 +22,7 @@ export function Close() {
           <img
             data-reveal
             src="/wordmark-light.svg"
-            alt="decdn_"
+            alt="decdn"
             className="block"
             style={{
               ["--wordmark-h" as string]: "clamp(4.75rem, 14vw, 11.5rem)",

--- a/components/site/Close.tsx
+++ b/components/site/Close.tsx
@@ -18,16 +18,19 @@ export function Close() {
             Contact
           </h2>
 
-          <div
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
             data-reveal
-            className="hug flex items-baseline gap-2 font-semibold tracking-[-0.05em]"
-            style={{ fontSize: "var(--fs-display)", lineHeight: "0.86" }}
-          >
-            <span>decdn</span>
-            <span aria-hidden style={{ color: "var(--whisper)" }}>
-              _
-            </span>
-          </div>
+            src="/wordmark-light.svg"
+            alt="decdn_"
+            className="block"
+            style={{
+              ["--wordmark-h" as string]: "clamp(4.75rem, 14vw, 11.5rem)",
+              height: "var(--wordmark-h)",
+              width: "auto",
+              marginLeft: "calc(var(--wordmark-h) * -0.18)",
+            }}
+          />
 
           {/* prettier-ignore */}
           <p

--- a/components/site/Close.tsx
+++ b/components/site/Close.tsx
@@ -23,6 +23,8 @@ export function Close() {
             data-reveal
             src="/wordmark-light.svg"
             alt="decdn"
+            width={411}
+            height={110}
             className="block"
             style={{
               ["--wordmark-h" as string]: "clamp(4.75rem, 14vw, 11.5rem)",


### PR DESCRIPTION
## Summary
- Replace the styled "decdn_" text in the Close (Contact) section with `public/wordmark-light.svg`, mirroring the existing `Chrome.tsx` `<img>` pattern (`output: "export"` rules out `next/image`).
- Give the wordmark its own fluid sizing curve (`clamp(4.75rem, 14vw, 11.5rem)`) so phones don't fall to the `--fs-display` floor.
- Apply a height-proportional negative `margin-left` so the mark visually outdents past the content's left edge across viewports.
- Drop the decorative trailing `_` from `alt` text on the wordmark `<img>` in both `Close.tsx` and `Chrome.tsx` (light/dark variants). The original text-based markup hid the underscore via `aria-hidden`; the new image now mirrors that behavior so screen readers announce "decdn" instead of "decdn underscore".

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm build` (static export) succeeds
- [x] `/#contact` renders the wordmark at ~360px, ~768px, ~1440px without overflow
- [x] Reveal animation still fires on scroll
- [x] VoiceOver (or any screen reader) announces the wordmark as "decdn", not "decdn underscore"

## Reviewer feedback
- **Accepted:** alt-text fix flagged by Copilot + Gemini (commit `bb1bb59`).
- **Rejected:** Gemini's suggestion to cast the whole `style` object as `React.CSSProperties` instead of the per-key `["--var" as string]` cast. The new code matches the existing `["--reveal-delay" as string]` pattern at `Close.tsx:36`; switching styles in one spot would diverge from neighboring code without functional benefit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)