### PR TITLE
refactor(site): extract footer into standalone global component

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,6 @@
 {
   "enabledPlugins": {
-    "frontend-design@claude-plugins-official": true
+    "frontend-design@claude-plugins-official": true,
+    "typescript-lsp@claude-plugins-official": true
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from "next";
 import { Geist } from "next/font/google";
 import { links, SITE_URL, INDEXABLE } from "@/lib/links";
 import { Chrome } from "@/components/site/Chrome";
+import { Footer } from "@/components/site/Footer";
 import { ScrollReveal } from "@/components/site/ScrollReveal";
 import "./globals.css";
 
@@ -95,6 +96,7 @@ export default function RootLayout({
         <Chrome />
         <ScrollReveal />
         {children}
+        <Footer />
       </body>
     </html>
   );

--- a/components/site/Close.tsx
+++ b/components/site/Close.tsx
@@ -88,20 +88,6 @@ export function Close() {
 
         <FleetStatus className="block w-full" />
       </div>
-
-      <footer className="mt-auto flex flex-col gap-3 pt-16">
-        <span aria-hidden className="rule opacity-40" />
-        <div
-          className="grid grid-cols-1 gap-2 tracking-[0.2em] uppercase opacity-80 @md:grid-cols-3 @md:items-center"
-          style={{ fontSize: "var(--fs-micro)" }}
-        >
-          <span>© decdn labs · open source</span>
-          <span className="@md:text-center">
-            built in rust · probably over-engineered
-          </span>
-          <span className="tabular-nums @md:text-right">node-001 / v0</span>
-        </div>
-      </footer>
     </Frame>
   );
 }

--- a/components/site/Footer.tsx
+++ b/components/site/Footer.tsx
@@ -1,0 +1,25 @@
+export function Footer() {
+  return (
+    <footer
+      className="bg-[var(--paper)] pt-16 pb-10 text-[var(--ink)]"
+      style={{ paddingInline: "var(--frame-gutter)" }}
+    >
+      <div
+        className="@container mx-auto flex flex-col gap-3"
+        style={{ maxWidth: "var(--frame-max)" }}
+      >
+        <span aria-hidden className="rule opacity-40" />
+        <div
+          className="grid grid-cols-1 gap-2 tracking-[0.2em] uppercase opacity-80 @md:grid-cols-3 @md:items-center"
+          style={{ fontSize: "var(--fs-micro)" }}
+        >
+          <span>© decdn labs · open source</span>
+          <span className="@md:text-center">
+            built in rust · probably over-engineered
+          </span>
+          <span className="tabular-nums @md:text-right">node-001 / v0</span>
+        </div>
+      </div>
+    </footer>
+  );
+}


### PR DESCRIPTION
## Summary
- Extract footer markup from `components/site/Close.tsx` into a new `components/site/Footer.tsx`.
- Render `<Footer />` globally from `app/layout.tsx` after `{children}`, alongside the already-global `<Chrome />` and `<ScrollReveal />`.
- `<footer>` is now a sibling of `<main>` (page-level `contentinfo` landmark) instead of nested inside a `<section>` inside `<main>`.

Forward-looking: future routes (e.g. `/docs`, `/pricing`) inherit the footer without per-page imports.

## Test plan
- [x] `pnpm lint` — clean
- [x] `pnpm build` — static export to `out/` succeeds, all 10 routes prerendered
- [ ] Visual: bottom of `/` renders the 3-column copyright row identically (paper background, rule line, `@md:grid-cols-3` breakpoint)
- [ ] Visual: Contact section transitions cleanly into footer (both paper, no seam)
- [ ] Responsive: <`@md` is 1 column, >=`@md` is 3 columns with centered middle + right-aligned right

🤖 Generated with [Claude Code](https://claude.com/claude-code)