### PR TITLE
fix(seo): render JSON-LD inside <head>

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -85,7 +85,7 @@ export default function RootLayout({
       lang="en"
       className={`${geistSans.variable} h-full motion-safe:scroll-smooth`}
     >
-      <body className="min-h-full">
+      <head>
         {[organizationSchema, websiteSchema].map((schema) => (
           <script
             key={schema["@id"]}
@@ -93,6 +93,8 @@ export default function RootLayout({
             dangerouslySetInnerHTML={{ __html: safeJSONLD(schema) }}
           />
         ))}
+      </head>
+      <body className="min-h-full">
         <Chrome />
         <ScrollReveal />
         {children}


### PR DESCRIPTION
## Summary

- Closes #57 — the `Organization` and `WebSite` JSON-LD blocks were rendering inside `<body>` in `out/index.html`, where some crawlers and validators (per [Google's structured-data guidelines](https://developers.google.com/search/docs/appearance/structured-data/intro-structured-data#format)) deprioritize or skip them.
- Mechanical relocation of the existing `.map(...)` block in `app/layout.tsx` from inside `<body>` into a new `<head>` element placed before `<body>`. Same schemas, same `safeJSONLD` XSS escape, same Next.js JSON-LD pattern.
- Why a custom `<head>` is OK in Next 16 App Router: the docs warning against manual `<head>` is scoped to `<title>`/`<meta>` (where the metadata API dedupes); JSON-LD scripts are out of scope. Next merges custom `<head>` children with the API-generated tags.

Considered and rejected: `head.tsx` (removed in App Router), `metadata.other` (emits `<meta>` only), `next/script beforeInteractive` (Next's JSON-LD guide says use a native `<script>`; React 19 only hoists async-src scripts).

## Test plan

- [x] `pnpm build` succeeds; 14 static pages
- [x] Precise grep for `<script type="application/ld+json"` shows **2 IN-HEAD, 0 IN-BODY** in `out/index.html`, `out/blog/index.html`, and `out/blog/decentralized-cdn-graveyard/index.html`
- [x] Metadata-API tags (`<title>`, `og:title`, canonical) still render in `<head>`
- [x] `pnpm lint` and `pnpm format:check` pass
- [ ] Post-merge: validate live URL with [Rich Results Test](https://search.google.com/test/rich-results); confirm both `Organization` and `WebSite` are detected

> Note: the awk one-liner in the issue gives a false negative against the static export — it matches the literal string `application/ld+json` everywhere, including the React Server Components serialized payload at the bottom of `<body>` (which contains escaped `"type":"application/ld+json"` as part of the React tree). A precise grep for the opening tag `<script type="application/ld+json"` is the reliable check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)