### PR TITLE
chore: copy + types tidy (close #58, #59, #54)

### DIFF
--- a/components/site/Close.tsx
+++ b/components/site/Close.tsx
@@ -3,6 +3,8 @@ import { Frame } from "@/components/ui/Frame";
 import { SectionHeader } from "@/components/ui/SectionHeader";
 import { FleetStatus } from "@/components/site/FleetStatus";
 
+const wordmarkH = "clamp(4.75rem, 14vw, 11.5rem)";
+
 export function Close() {
   return (
     <Frame id="contact" tone="paper" className="overflow-hidden">
@@ -27,10 +29,9 @@ export function Close() {
             height={110}
             className="block"
             style={{
-              "--wordmark-h": "clamp(4.75rem, 14vw, 11.5rem)",
-              height: "var(--wordmark-h)",
+              height: wordmarkH,
               width: "auto",
-              marginLeft: "calc(var(--wordmark-h) * -0.18)",
+              marginLeft: `calc(${wordmarkH} * -0.18)`,
             }}
           />
 

--- a/components/site/Close.tsx
+++ b/components/site/Close.tsx
@@ -66,9 +66,9 @@ export function Close() {
             <a
               className="underline-brutal font-semibold tracking-[0.02em]"
               style={{ fontSize: "var(--fs-lead)" }}
-              href={links.runNode}
+              href={links.docs}
             >
-              run a node
+              read the docs
               <span className="arrow" aria-hidden>
                 →
               </span>

--- a/components/site/Faq.tsx
+++ b/components/site/Faq.tsx
@@ -43,11 +43,6 @@ export function Faq() {
             q="Can publishers pay on behalf of users?"
             a="Yes. Account abstraction lets a publisher fund a payment channel for their audience, so users pull content with no wallet and no subscription — same free-to-download experience as a public mirror, except the publisher pays peers per megabyte instead of one cloud's egress bill. Default flow is client-pays; publisher-pays is the flag you flip when you want to ship widely without per-user payment friction."
           />
-          <FaqItem
-            delay={400}
-            q="Does this work well for AI models?"
-            a="Yes — AI is where deCDN's primitives compound. Clients pull large weights from several peers in parallel and saturate their own uplink instead of a single origin's. BLAKE3 chunk addressing lets teams grab one quantisation variant or a single layer without downloading the full checkpoint. And when a model drops and every region pulls it at once, the mesh warms around the demand instead of choking at a central bucket."
-          />
         </dl>
       </div>
     </Frame>

--- a/components/site/Hero.tsx
+++ b/components/site/Hero.tsx
@@ -63,9 +63,9 @@ export function Hero() {
               <a
                 className="underline-brutal font-semibold tracking-[0.14em] uppercase"
                 style={{ fontSize: "var(--fs-cta)" }}
-                href={links.runNode}
+                href={links.docs}
               >
-                run a node
+                read the docs
                 <span className="arrow" aria-hidden>
                   →
                 </span>

--- a/lib/links.ts
+++ b/lib/links.ts
@@ -4,7 +4,6 @@ export const links = {
   x: "https://x.com/deCDNorg",
   litepaper: "/decdn_litepaper.pdf",
   docs: "https://docs.decdn.org/overview/introduction",
-  runNode: "https://docs.decdn.org/overview/introduction",
   contact: "mailto:info@decdn.org",
 } as const;
 

--- a/types/css.d.ts
+++ b/types/css.d.ts
@@ -3,6 +3,5 @@ import "react";
 declare module "react" {
   interface CSSProperties {
     "--reveal-delay"?: `${number}ms`;
-    "--wordmark-h"?: string;
   }
 }


### PR DESCRIPTION
## Summary

Three small unclaimed issues bundled into one PR. Each is mechanical, one commit each, no shared state between them beyond all three touching one or two top-level components.

- **Closes #58** — Remove the AI-models FAQ entry (last `FaqItem` in `components/site/Faq.tsx`). Preceding `delay={320}` item is now the trailing one; reveal cadence unchanged.
- **Closes #59** — Hero and Close CTAs read "read the docs →" pointing at `links.docs` (same-tab, matches the pre-existing `run a node` link behavior — `target="_blank"` deliberately not added). Orphaned `runNode:` entry removed from `lib/links.ts` (it was an identical string to `docs` and the two call sites were its only references).
- **Closes #54** — `--wordmark-h` is consumed only inside the same JSX subtree that declared it (Close.tsx), so it's inlined as a local `const wordmarkH`. The entry is dropped from `types/css.d.ts`, narrowing the global `CSSProperties` augmentation back to `--reveal-delay` (the only token that genuinely bridges JSX → CSS rules in `globals.css`).

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm exec prettier --check .` — clean
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm build` — static export succeeds; 10 pages prerendered
- [x] `out/index.html` checks:
  - `grep "Does this work well for AI models"` → 0
  - `grep "run a node"` → 0
  - 2 visible `read the docs` anchors pointing at `https://docs.decdn.org/overview/introduction`, no `target="_blank"`
  - No `wordmark-h` leakage anywhere under `out/`
- [ ] Eyeball at `pnpm dev`:
  - FAQ shows 5 items, last is "Can publishers pay on behalf of users?"
  - Hero CTA cluster: `read the litepaper →` (new tab) · `read the docs →` (same tab) · `source →`
  - Close CTA cluster: same shape with the longer `read the litepaper` / `read the docs` / `source on github`
  - Close wordmark sizes identically to current production (size + negative margin unchanged)