### PR TITLE
chore(theme): migrate footer to Tailwind theme utilities

### DIFF
--- a/components/site/Footer.tsx
+++ b/components/site/Footer.tsx
@@ -1,7 +1,7 @@
 export function Footer() {
   return (
     <footer
-      className="bg-[var(--paper)] pt-16 pb-10 text-[var(--ink)]"
+      className="bg-paper pt-16 pb-10 text-ink"
       style={{ paddingInline: "var(--frame-gutter)" }}
     >
       <div


### PR DESCRIPTION
## Summary

Follow-up to #75. Copilot's review on that PR ([discussion](https://github.com/decdn/website/pull/75#discussion_r3220076693)) caught one site that the audit refresh on #4 missed:

- `components/site/Footer.tsx:4` — `bg-[var(--paper)] pt-16 pb-10 text-[var(--ink)]` → `bg-paper pt-16 pb-10 text-ink`.

Other `var(--…)` uses in `Footer.tsx` (lines 5, 9, 14) target `--frame-gutter`, `--frame-max`, and `--fs-micro` — layout/typography vars, not theme colors, so they're out of scope for #4.

## No visual change

Same reasoning as #75: `--color-paper` / `--color-ink` in `@theme inline` are aliased to `var(--paper)` / `var(--ink)`. Old and new classes resolve to identical CSS.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm build` (static export)

🤖 Generated with [Claude Code](https://claude.com/claude-code)