### PR TITLE
feat(seo): list litepaper PDF in sitemap-pages.xml (close #40)

### DIFF
--- a/app/sitemap-pages.xml/route.ts
+++ b/app/sitemap-pages.xml/route.ts
@@ -28,6 +28,7 @@ const postUrls = listPosts()
 const BODY = `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url><loc>${SITE_URL}</loc></url>
+  <url><loc>${SITE_URL}decdn_litepaper.pdf</loc></url>
   <url><loc>${SITE_URL}blog/</loc></url>
 ${postUrls}
 </urlset>


### PR DESCRIPTION
## Summary

- Adds `${SITE_URL}decdn_litepaper.pdf` to `app/sitemap-pages.xml/route.ts` so crawlers discover the litepaper alongside the homepage and blog posts.
- Closes #40.

## Why

The litepaper is the deepest CTA on the site (Hero, Chrome, Close) and the audience arriving via whitepaper-style queries ("decentralised CDN whitepaper", "USDC content delivery") is exactly the technical/investor segment we want.

The versioning concern raised in #40 was resolved by 2d913d3, which renamed the file from `litepaper-v2.pdf` to the unversioned `/decdn_litepaper.pdf` — the sitemap entry no longer needs to churn on each litepaper revision.

## Test plan

- [x] `pnpm build` — static export succeeds.
- [x] `grep -c "decdn_litepaper.pdf" out/sitemap-pages.xml` returns `1`.
- [x] `out/decdn_litepaper.pdf` is still emitted.
- [x] `pnpm lint` — clean.
- [ ] After merge: request a fetch of `https://decdn.org/sitemap.xml` in Google Search Console so the index re-validates and picks up the new entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)