### PR TITLE
fix(nav): elevate the navbar when the drawer is open

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -736,14 +736,10 @@ a.underline-brutal:hover .arrow {
   border-bottom-color: color-mix(in srgb, var(--paper) 26%, transparent);
 }
 
-/* Drawer open: lift the nav above the overlay (55) but leave it below
-   the panel (60) so the panel still covers it. Drop the translucent
-   backdrop for a fully opaque section-toned bar with a soft drop
-   shadow — without the shadow, an opaque paper nav on a paper
-   section (or ink on ink) reads as no nav at all, because the band
-   has no contrast against the section behind it. The shadow gives
-   the band depth so it reads as an elevated header. Tone keeps
-   tracking the section behind the nav. */
+/* Drawer open: lift the nav above the overlay (55) and below the
+   panel (60), and swap the translucent backdrop for an opaque
+   section-toned bar. The shadow is load-bearing — without it, paper
+   nav on paper section (or ink on ink) reads as no nav at all. */
 .chrome-nav[data-mobile-open="true"] {
   backdrop-filter: none;
   -webkit-backdrop-filter: none;

--- a/app/globals.css
+++ b/app/globals.css
@@ -835,6 +835,7 @@ a.underline-brutal:hover .arrow {
   .chrome-nav {
     transition:
       background-color 260ms cubic-bezier(0.2, 0.8, 0.2, 1),
+      border-bottom-color 260ms cubic-bezier(0.2, 0.8, 0.2, 1),
       box-shadow 360ms cubic-bezier(0.2, 0.8, 0.2, 1);
   }
   .nav-item .nav-label,

--- a/app/globals.css
+++ b/app/globals.css
@@ -749,14 +749,12 @@ a.underline-brutal:hover .arrow {
   -webkit-backdrop-filter: none;
   z-index: 58;
 }
-.chrome-nav[data-mobile-open="true"][data-tone="paper"],
-.chrome-nav[data-mobile-open="true"][data-tone="paper"][data-scrolled="true"] {
+.chrome-nav[data-mobile-open="true"][data-tone="paper"] {
   background-color: var(--paper);
   border-bottom-color: color-mix(in srgb, var(--ink) 24%, transparent);
   box-shadow: 0 10px 22px -12px color-mix(in srgb, var(--ink) 26%, transparent);
 }
-.chrome-nav[data-mobile-open="true"][data-tone="ink"],
-.chrome-nav[data-mobile-open="true"][data-tone="ink"][data-scrolled="true"] {
+.chrome-nav[data-mobile-open="true"][data-tone="ink"] {
   background-color: var(--ink);
   border-bottom-color: color-mix(in srgb, var(--paper) 26%, transparent);
   box-shadow: 0 10px 22px -12px
@@ -839,7 +837,9 @@ a.underline-brutal:hover .arrow {
 
 @media (prefers-reduced-motion: reduce) {
   .chrome-nav {
-    transition: background-color 260ms cubic-bezier(0.2, 0.8, 0.2, 1);
+    transition:
+      background-color 260ms cubic-bezier(0.2, 0.8, 0.2, 1),
+      box-shadow 360ms cubic-bezier(0.2, 0.8, 0.2, 1);
   }
   .nav-item .nav-label,
   .nav-item .nav-underline {

--- a/app/globals.css
+++ b/app/globals.css
@@ -714,6 +714,7 @@ a.underline-brutal:hover .arrow {
     backdrop-filter 260ms cubic-bezier(0.2, 0.8, 0.2, 1),
     -webkit-backdrop-filter 260ms cubic-bezier(0.2, 0.8, 0.2, 1),
     border-bottom-color 260ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    box-shadow 360ms cubic-bezier(0.2, 0.8, 0.2, 1),
     color 300ms cubic-bezier(0.2, 0.8, 0.2, 1);
 }
 
@@ -733,6 +734,33 @@ a.underline-brutal:hover .arrow {
 .chrome-nav[data-scrolled="true"][data-tone="ink"] {
   background-color: color-mix(in srgb, var(--ink) 92%, transparent);
   border-bottom-color: color-mix(in srgb, var(--paper) 26%, transparent);
+}
+
+/* Drawer open: lift the nav above the overlay (55) but leave it below
+   the panel (60) so the panel still covers it. Drop the translucent
+   backdrop for a fully opaque section-toned bar with a soft drop
+   shadow — without the shadow, an opaque paper nav on a paper
+   section (or ink on ink) reads as no nav at all, because the band
+   has no contrast against the section behind it. The shadow gives
+   the band depth so it reads as an elevated header. Tone keeps
+   tracking the section behind the nav. */
+.chrome-nav[data-mobile-open="true"] {
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+  z-index: 58;
+}
+.chrome-nav[data-mobile-open="true"][data-tone="paper"],
+.chrome-nav[data-mobile-open="true"][data-tone="paper"][data-scrolled="true"] {
+  background-color: var(--paper);
+  border-bottom-color: color-mix(in srgb, var(--ink) 24%, transparent);
+  box-shadow: 0 10px 22px -12px color-mix(in srgb, var(--ink) 26%, transparent);
+}
+.chrome-nav[data-mobile-open="true"][data-tone="ink"],
+.chrome-nav[data-mobile-open="true"][data-tone="ink"][data-scrolled="true"] {
+  background-color: var(--ink);
+  border-bottom-color: color-mix(in srgb, var(--paper) 26%, transparent);
+  box-shadow: 0 10px 22px -12px
+    color-mix(in srgb, var(--paper) 22%, transparent);
 }
 
 /* Safari <17 etc.: if backdrop-filter isn't supported, collapse to a

--- a/components/site/Chrome.tsx
+++ b/components/site/Chrome.tsx
@@ -117,11 +117,12 @@ export function Chrome() {
   }, []);
 
   const onDark = DARK_SECTIONS.has(active);
-  // The toggle is portalled to <body> (see MobileMenu.tsx), so it
-  // paints on top of the white panel while the drawer is open — force
-  // it to paper then. The rest of the nav stays at z-50 behind the
-  // drawer, visible only in the strip the panel doesn't cover, and
-  // keeps tracking `onDark`.
+  // The toggle is portalled to <body> (see MobileMenu.tsx) and lives
+  // on top of the paper panel while the drawer is open — force it to
+  // paper then so its × reads against the white panel. The rest of
+  // the nav stays section-toned; data-mobile-open just lifts it above
+  // the overlay and turns its translucent backdrop opaque so section
+  // content stops bleeding through the visible left strip.
   const toggleTone = mobileOpen ? "paper" : onDark ? "ink" : "paper";
 
   return (
@@ -130,6 +131,7 @@ export function Chrome() {
       aria-label="Primary"
       data-scrolled={scrolled ? "true" : undefined}
       data-tone={onDark ? "ink" : "paper"}
+      data-mobile-open={mobileOpen ? "true" : undefined}
       className={`chrome-nav fixed inset-x-0 top-0 z-50 py-5 ${
         onDark ? "text-paper" : "text-ink"
       }`}

--- a/components/site/Chrome.tsx
+++ b/components/site/Chrome.tsx
@@ -119,10 +119,7 @@ export function Chrome() {
   const onDark = DARK_SECTIONS.has(active);
   // The toggle is portalled to <body> (see MobileMenu.tsx) and lives
   // on top of the paper panel while the drawer is open — force it to
-  // paper then so its × reads against the white panel. The rest of
-  // the nav stays section-toned; data-mobile-open just lifts it above
-  // the overlay and turns its translucent backdrop opaque so section
-  // content stops bleeding through the visible left strip.
+  // paper then so its × reads against the white panel.
   const toggleTone = mobileOpen ? "paper" : onDark ? "ink" : "paper";
 
   return (

--- a/components/site/MobileMenu.tsx
+++ b/components/site/MobileMenu.tsx
@@ -45,6 +45,11 @@ const FOCUSABLE_SELECTOR =
 // browser's default smooth-scroll, but linear so the page doesn't
 // burst forward and then slow to a crawl the way ease-out curves do
 // (especially noticeable behind the drawer's slide-close).
+// `<html>` scroll-behavior is forced to `auto` for the lifetime of
+// the rAF: without it, each per-frame `window.scrollTo` defers to
+// the page's `motion-safe:scroll-smooth` CSS and queues yet another
+// browser-managed smooth animation, which fights the rAF and reads
+// as a lumpy "slow then sudden" scroll.
 // Reduced-motion path jumps instantly via scrollIntoView (still
 // honours the element's scroll-margin-top).
 function scrollToAnchor(el: HTMLElement) {
@@ -58,12 +63,19 @@ function scrollToAnchor(el: HTMLElement) {
   const targetY = startY + el.getBoundingClientRect().top - marginTop;
   const distance = targetY - startY;
   if (distance === 0) return;
+  const html = document.documentElement;
+  const prevScrollBehavior = html.style.scrollBehavior;
+  html.style.scrollBehavior = "auto";
   const duration = 600;
   const startTime = performance.now();
   const tick = (now: number) => {
     const t = Math.min(1, (now - startTime) / duration);
     window.scrollTo(0, startY + distance * t);
-    if (t < 1) requestAnimationFrame(tick);
+    if (t < 1) {
+      requestAnimationFrame(tick);
+    } else {
+      html.style.scrollBehavior = prevScrollBehavior;
+    }
   };
   requestAnimationFrame(tick);
 }

--- a/components/site/MobileMenu.tsx
+++ b/components/site/MobileMenu.tsx
@@ -144,7 +144,14 @@ export function MobileMenu({ activeSection, tone, onOpenChange }: Props) {
       document.removeEventListener("keydown", onKey);
       // Removing `position: fixed` snaps the page back to y=0 because
       // the negative `top` was the only thing holding the viewport in
-      // place — scroll somewhere explicitly after restoring styles.
+      // place. Restore the prior scroll synchronously and **instantly**
+      // — `behavior: "instant"` bypasses the page's
+      // `motion-safe:scroll-smooth`, which would otherwise animate
+      // from y=0 back to the saved position and read as "the page
+      // jumped to the top and scrolled down again" on close. With the
+      // instant restore in place, close-only stays put and anchor taps
+      // become a clean smooth ride from the prior position to the
+      // target instead of a jump-then-descent.
       const prev = prevBodyStyleRef.current!;
       const style = document.body.style;
       style.position = prev.position;
@@ -154,15 +161,20 @@ export function MobileMenu({ activeSection, tone, onOpenChange }: Props) {
       style.width = prev.width;
       style.overflow = prev.overflow;
       prevBodyStyleRef.current = null;
+      window.scrollTo({
+        top: scrollYRef.current,
+        left: 0,
+        behavior: "instant",
+      });
 
       const anchor = pendingAnchorRef.current;
       pendingAnchorRef.current = null;
       if (anchor) {
         const el = document.getElementById(anchor);
         if (el) {
-          // history.replaceState doesn't scroll; smooth-scroll via
-          // scrollIntoView. `motion-safe:scroll-smooth` on <html>
-          // honours reduced-motion automatically.
+          // history.replaceState doesn't scroll; scrollIntoView rides
+          // on the just-restored scroll position via the page's
+          // `motion-safe:scroll-smooth` (honours reduced-motion).
           history.replaceState(null, "", `#${anchor}`);
           el.scrollIntoView({ block: "start" });
         } else {
@@ -170,8 +182,6 @@ export function MobileMenu({ activeSection, tone, onOpenChange }: Props) {
           // /blog/*). Let the browser navigate to home + hash.
           window.location.assign(`/#${anchor}`);
         }
-      } else {
-        window.scrollTo(0, scrollYRef.current);
       }
     };
   }, [open]);

--- a/components/site/MobileMenu.tsx
+++ b/components/site/MobileMenu.tsx
@@ -41,10 +41,10 @@ const EXTERNAL: readonly DrawerLink[] = [
 const FOCUSABLE_SELECTOR =
   'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
-// Slow, editorial scroll to an anchor — matches the drawer's 720ms
-// open and 850ms brutal-rise reveals rather than the browser's
-// snappy default smooth-scroll. easeOutExpo gives the heavy
-// settling-into-place feel the rest of the page uses.
+// Constant-velocity scroll to an anchor at 600ms — slower than the
+// browser's default smooth-scroll, but linear so the page doesn't
+// burst forward and then slow to a crawl the way ease-out curves do
+// (especially noticeable behind the drawer's slide-close).
 // Reduced-motion path jumps instantly via scrollIntoView (still
 // honours the element's scroll-margin-top).
 function scrollToAnchor(el: HTMLElement) {
@@ -58,12 +58,11 @@ function scrollToAnchor(el: HTMLElement) {
   const targetY = startY + el.getBoundingClientRect().top - marginTop;
   const distance = targetY - startY;
   if (distance === 0) return;
-  const duration = 900;
+  const duration = 600;
   const startTime = performance.now();
   const tick = (now: number) => {
     const t = Math.min(1, (now - startTime) / duration);
-    const eased = t === 1 ? 1 : 1 - Math.pow(2, -10 * t);
-    window.scrollTo(0, startY + distance * eased);
+    window.scrollTo(0, startY + distance * t);
     if (t < 1) requestAnimationFrame(tick);
   };
   requestAnimationFrame(tick);
@@ -212,8 +211,7 @@ export function MobileMenu({ activeSection, tone, onOpenChange }: Props) {
 
       if (anchor && targetEl) {
         // replaceState doesn't scroll; scrollToAnchor rides from the
-        // just-restored position to the target over 900ms — slow
-        // enough to feel of-a-piece with the drawer's slide-close.
+        // just-restored position to the target at constant velocity.
         history.replaceState(null, "", `#${anchor}`);
         scrollToAnchor(targetEl);
       }

--- a/components/site/MobileMenu.tsx
+++ b/components/site/MobileMenu.tsx
@@ -8,7 +8,6 @@ import {
   useSyncExternalStore,
 } from "react";
 import { createPortal } from "react-dom";
-import { useRouter } from "next/navigation";
 import { links } from "@/lib/links";
 
 type SectionId = "intro" | "compare" | "method" | "faq" | "contact";
@@ -41,43 +40,54 @@ const EXTERNAL: readonly DrawerLink[] = [
 const FOCUSABLE_SELECTOR =
   'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
-// Constant-velocity scroll to an anchor at 600ms — slower than the
-// browser's default smooth-scroll, but linear so the page doesn't
-// burst forward and then slow to a crawl the way ease-out curves do
-// (especially noticeable behind the drawer's slide-close).
 // `<html>` scroll-behavior is forced to `auto` for the lifetime of
 // the rAF: without it, each per-frame `window.scrollTo` defers to
-// the page's `motion-safe:scroll-smooth` CSS and queues yet another
-// browser-managed smooth animation, which fights the rAF and reads
-// as a lumpy "slow then sudden" scroll.
-// Reduced-motion path jumps instantly via scrollIntoView (still
-// honours the element's scroll-margin-top).
+// `motion-safe:scroll-smooth` and queues yet another browser
+// smooth-scroll per tick, which fights the rAF and reads as a
+// lumpy "slow then sudden" scroll. The loop is single-flight — a
+// new call cancels any in-flight rAF and eagerly restores its
+// captured scroll-behavior so we never snapshot the polluted
+// "auto" value (which would otherwise survive past the helper and
+// permanently override the page's CSS scroll-smooth).
+let scrollAnchorRaf = 0;
+let scrollAnchorRestore: (() => void) | null = null;
+
 function scrollToAnchor(el: HTMLElement) {
   if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
     el.scrollIntoView({ block: "start" });
     return;
   }
+  if (scrollAnchorRaf !== 0) {
+    cancelAnimationFrame(scrollAnchorRaf);
+    scrollAnchorRestore?.();
+    scrollAnchorRaf = 0;
+    scrollAnchorRestore = null;
+  }
   const startY = window.scrollY;
-  const marginTop =
-    parseFloat(getComputedStyle(el).scrollMarginTop || "0") || 0;
+  const marginTop = parseFloat(getComputedStyle(el).scrollMarginTop);
   const targetY = startY + el.getBoundingClientRect().top - marginTop;
   const distance = targetY - startY;
   if (distance === 0) return;
   const html = document.documentElement;
   const prevScrollBehavior = html.style.scrollBehavior;
   html.style.scrollBehavior = "auto";
+  scrollAnchorRestore = () => {
+    html.style.scrollBehavior = prevScrollBehavior;
+  };
   const duration = 600;
   const startTime = performance.now();
   const tick = (now: number) => {
     const t = Math.min(1, (now - startTime) / duration);
     window.scrollTo(0, startY + distance * t);
     if (t < 1) {
-      requestAnimationFrame(tick);
+      scrollAnchorRaf = requestAnimationFrame(tick);
     } else {
-      html.style.scrollBehavior = prevScrollBehavior;
+      scrollAnchorRestore?.();
+      scrollAnchorRestore = null;
+      scrollAnchorRaf = 0;
     }
   };
-  requestAnimationFrame(tick);
+  scrollAnchorRaf = requestAnimationFrame(tick);
 }
 
 // Hydration gate for the createPortal target. Reads false on the
@@ -88,7 +98,6 @@ const getHydratedSnapshot = () => true;
 const getServerSnapshot = () => false;
 
 export function MobileMenu({ activeSection, tone, onOpenChange }: Props) {
-  const router = useRouter();
   const [open, setOpen] = useState(false);
   // Static export: document.body isn't available during prerender. Gate
   // the portal until after hydration so the first client render matches
@@ -200,12 +209,12 @@ export function MobileMenu({ activeSection, tone, onOpenChange }: Props) {
       const targetEl = anchor ? document.getElementById(anchor) : null;
 
       if (anchor && !targetEl) {
-        // Drawer opened from a different route (e.g. /blog/*); the
-        // new page handles the hash scroll. Use router.push so the
-        // transition stays client-side instead of a full reload.
-        // Skip the local restore — any scroll on this page would be
-        // a visible artefact on the way out.
-        router.push(`/#${anchor}`);
+        // Drawer opened from a different route (e.g. /blog/*); a
+        // full reload to /#anchor lets the new page handle the hash
+        // scroll deterministically (Next 16 App Router's soft-nav
+        // hash behaviour under output: "export" isn't documented).
+        // Skip the local restore — the page is about to unload.
+        window.location.assign(`/#${anchor}`);
         return;
       }
 
@@ -222,13 +231,13 @@ export function MobileMenu({ activeSection, tone, onOpenChange }: Props) {
       html.style.scrollBehavior = prevScrollBehavior;
 
       if (anchor && targetEl) {
-        // replaceState doesn't scroll; scrollToAnchor rides from the
-        // just-restored position to the target at constant velocity.
+        // replaceState updates the URL without scrolling;
+        // scrollToAnchor does the visible scroll.
         history.replaceState(null, "", `#${anchor}`);
         scrollToAnchor(targetEl);
       }
     };
-  }, [open, router]);
+  }, [open]);
 
   // Skipped on the initial render (when `open` is already false) via
   // the wasOpenRef guard.
@@ -268,9 +277,10 @@ export function MobileMenu({ activeSection, tone, onOpenChange }: Props) {
 
   // Portal target: toggle/overlay/panel all live in <body> so the
   // toggle can sit above the panel (z-65 > z-60) while the wordmark
-  // stays inside the nav at z-50 and is naturally covered when the
-  // drawer opens. Raising the nav's z-index would lift the wordmark
-  // above the drawer too, which it shouldn't be.
+  // stays inside the nav (z-50 resting, z-58 when the drawer opens
+  // — see Chrome.tsx + globals.css's data-mobile-open block). The
+  // nav always sits below the panel, so the wordmark is naturally
+  // covered when the drawer opens.
   const drawer = (
     <>
       <button

--- a/components/site/MobileMenu.tsx
+++ b/components/site/MobileMenu.tsx
@@ -32,9 +32,9 @@ type DrawerLink = {
 };
 
 const EXTERNAL: readonly DrawerLink[] = [
-  { kind: "internal", href: links.docs, label: "Docs" },
-  { kind: "internal", href: links.blog, label: "Blog" },
-  { kind: "external", href: links.litepaper, label: "Litepaper" },
+  { kind: "internal", href: links.docs, label: "docs" },
+  { kind: "internal", href: links.blog, label: "blog" },
+  { kind: "external", href: links.litepaper, label: "litepaper" },
 ] as const;
 
 const FOCUSABLE_SELECTOR =
@@ -313,7 +313,9 @@ export function MobileMenu({ activeSection, tone, onOpenChange }: Props) {
         </ul>
 
         <footer className="mm-foot">
-          <span className="meta">decdn / labs</span>
+          <span className="meta">
+            decdn<span className="text-whisper">_</span>labs
+          </span>
         </footer>
       </aside>
     </>

--- a/components/site/MobileMenu.tsx
+++ b/components/site/MobileMenu.tsx
@@ -142,16 +142,8 @@ export function MobileMenu({ activeSection, tone, onOpenChange }: Props) {
     return () => {
       cancelAnimationFrame(raf);
       document.removeEventListener("keydown", onKey);
-      // Removing `position: fixed` snaps the page back to y=0 because
-      // the negative `top` was the only thing holding the viewport in
-      // place. Restore the prior scroll synchronously and **instantly**
-      // — `behavior: "instant"` bypasses the page's
-      // `motion-safe:scroll-smooth`, which would otherwise animate
-      // from y=0 back to the saved position and read as "the page
-      // jumped to the top and scrolled down again" on close. With the
-      // instant restore in place, close-only stays put and anchor taps
-      // become a clean smooth ride from the prior position to the
-      // target instead of a jump-then-descent.
+      // Removing `position: fixed` leaves the viewport at y=0 — the
+      // negative `top` was the only thing holding it.
       const prev = prevBodyStyleRef.current!;
       const style = document.body.style;
       style.position = prev.position;
@@ -161,27 +153,37 @@ export function MobileMenu({ activeSection, tone, onOpenChange }: Props) {
       style.width = prev.width;
       style.overflow = prev.overflow;
       prevBodyStyleRef.current = null;
-      window.scrollTo({
-        top: scrollYRef.current,
-        left: 0,
-        behavior: "instant",
-      });
 
       const anchor = pendingAnchorRef.current;
       pendingAnchorRef.current = null;
-      if (anchor) {
-        const el = document.getElementById(anchor);
-        if (el) {
-          // history.replaceState doesn't scroll; scrollIntoView rides
-          // on the just-restored scroll position via the page's
-          // `motion-safe:scroll-smooth` (honours reduced-motion).
-          history.replaceState(null, "", `#${anchor}`);
-          el.scrollIntoView({ block: "start" });
-        } else {
-          // Anchor target lives on another route (drawer opened from
-          // /blog/*). Let the browser navigate to home + hash.
-          window.location.assign(`/#${anchor}`);
-        }
+      const targetEl = anchor ? document.getElementById(anchor) : null;
+
+      if (anchor && !targetEl) {
+        // Drawer opened from a different route (e.g. /blog/*); the
+        // new page handles the hash scroll. Skip the local restore —
+        // any scroll on this page would be a visible artefact on the
+        // way out.
+        window.location.assign(`/#${anchor}`);
+        return;
+      }
+
+      // Restore the prior scroll position synchronously. We bypass
+      // `<html>`'s motion-safe:scroll-smooth manually instead of
+      // passing `behavior: "instant"` — Safari only honoured the
+      // "instant" enum from 18.4; older versions silently fall back
+      // to "auto", which re-introduces the smooth scroll from y=0
+      // we're trying to suppress.
+      const html = document.documentElement;
+      const prevScrollBehavior = html.style.scrollBehavior;
+      html.style.scrollBehavior = "auto";
+      window.scrollTo(0, scrollYRef.current);
+      html.style.scrollBehavior = prevScrollBehavior;
+
+      if (anchor && targetEl) {
+        // replaceState doesn't scroll; scrollIntoView smooth-scrolls
+        // from the just-restored position via motion-safe:scroll-smooth.
+        history.replaceState(null, "", `#${anchor}`);
+        targetEl.scrollIntoView({ block: "start" });
       }
     };
   }, [open]);

--- a/components/site/MobileMenu.tsx
+++ b/components/site/MobileMenu.tsx
@@ -8,6 +8,7 @@ import {
   useSyncExternalStore,
 } from "react";
 import { createPortal } from "react-dom";
+import { useRouter } from "next/navigation";
 import { links } from "@/lib/links";
 
 type SectionId = "intro" | "compare" | "method" | "faq" | "contact";
@@ -48,6 +49,7 @@ const getHydratedSnapshot = () => true;
 const getServerSnapshot = () => false;
 
 export function MobileMenu({ activeSection, tone, onOpenChange }: Props) {
+  const router = useRouter();
   const [open, setOpen] = useState(false);
   // Static export: document.body isn't available during prerender. Gate
   // the portal until after hydration so the first client render matches
@@ -160,10 +162,11 @@ export function MobileMenu({ activeSection, tone, onOpenChange }: Props) {
 
       if (anchor && !targetEl) {
         // Drawer opened from a different route (e.g. /blog/*); the
-        // new page handles the hash scroll. Skip the local restore —
-        // any scroll on this page would be a visible artefact on the
-        // way out.
-        window.location.assign(`/#${anchor}`);
+        // new page handles the hash scroll. Use router.push so the
+        // transition stays client-side instead of a full reload.
+        // Skip the local restore — any scroll on this page would be
+        // a visible artefact on the way out.
+        router.push(`/#${anchor}`);
         return;
       }
 
@@ -186,7 +189,7 @@ export function MobileMenu({ activeSection, tone, onOpenChange }: Props) {
         targetEl.scrollIntoView({ block: "start" });
       }
     };
-  }, [open]);
+  }, [open, router]);
 
   // Skipped on the initial render (when `open` is already false) via
   // the wasOpenRef guard.
@@ -314,7 +317,11 @@ export function MobileMenu({ activeSection, tone, onOpenChange }: Props) {
 
         <footer className="mm-foot">
           <span className="meta">
-            decdn<span className="text-whisper">_</span>labs
+            decdn
+            <span aria-hidden="true" className="text-whisper">
+              _
+            </span>
+            labs
           </span>
         </footer>
       </aside>

--- a/components/site/MobileMenu.tsx
+++ b/components/site/MobileMenu.tsx
@@ -41,6 +41,34 @@ const EXTERNAL: readonly DrawerLink[] = [
 const FOCUSABLE_SELECTOR =
   'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
+// Slow, editorial scroll to an anchor — matches the drawer's 720ms
+// open and 850ms brutal-rise reveals rather than the browser's
+// snappy default smooth-scroll. easeOutExpo gives the heavy
+// settling-into-place feel the rest of the page uses.
+// Reduced-motion path jumps instantly via scrollIntoView (still
+// honours the element's scroll-margin-top).
+function scrollToAnchor(el: HTMLElement) {
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+    el.scrollIntoView({ block: "start" });
+    return;
+  }
+  const startY = window.scrollY;
+  const marginTop =
+    parseFloat(getComputedStyle(el).scrollMarginTop || "0") || 0;
+  const targetY = startY + el.getBoundingClientRect().top - marginTop;
+  const distance = targetY - startY;
+  if (distance === 0) return;
+  const duration = 900;
+  const startTime = performance.now();
+  const tick = (now: number) => {
+    const t = Math.min(1, (now - startTime) / duration);
+    const eased = t === 1 ? 1 : 1 - Math.pow(2, -10 * t);
+    window.scrollTo(0, startY + distance * eased);
+    if (t < 1) requestAnimationFrame(tick);
+  };
+  requestAnimationFrame(tick);
+}
+
 // Hydration gate for the createPortal target. Reads false on the
 // server and true after hydration, without a useState+useEffect
 // round-trip that would trip the react-hooks/set-state-in-effect rule.
@@ -183,10 +211,11 @@ export function MobileMenu({ activeSection, tone, onOpenChange }: Props) {
       html.style.scrollBehavior = prevScrollBehavior;
 
       if (anchor && targetEl) {
-        // replaceState doesn't scroll; scrollIntoView smooth-scrolls
-        // from the just-restored position via motion-safe:scroll-smooth.
+        // replaceState doesn't scroll; scrollToAnchor rides from the
+        // just-restored position to the target over 900ms — slow
+        // enough to feel of-a-piece with the drawer's slide-close.
         history.replaceState(null, "", `#${anchor}`);
-        targetEl.scrollIntoView({ block: "start" });
+        scrollToAnchor(targetEl);
       }
     };
   }, [open, router]);


### PR DESCRIPTION
## Summary

Four improvements to the mobile drawer that all surfaced after PR #56 landed.

1. **Nav band visually vanished while the drawer was open.** With the section-toned nav painted in the same colour as the section behind it and the drawer's overlay (`z-55`) dimming the strip, the wordmark appeared to float on a dim page with no surrounding header.
2. **Closing the drawer scrolled "from the top."** The close-effect cleanup restored the saved scroll via `window.scrollTo`, which `<html>`'s `motion-safe:scroll-smooth` then animated from `y=0` (where unpinning the body left the viewport) back up to the saved position — reading as a jump to the top and a smooth descent.
3. **Typography polish.** The drawer's external link list was Title-Cased (`Docs / Blog / Litepaper`) while the section rows above it were lowercase — inconsistent. The footer read `decdn / labs` instead of echoing the wordmark's underscore mark.
4. **Section-anchor scroll choreography.** Browser default smooth-scroll completed in ~300-500ms, which read as snappy next to the drawer's 720ms slide. An attempt at 900ms easeOutExpo overcorrected; an attempt at 600ms linear-rAF fought with `<html>`'s CSS scroll-smooth (each per-frame `scrollTo` queued another browser smooth animation toward a moving target, producing lumpy velocity). The final answer is 600ms linear rAF with `<html>` `scroll-behavior` forced to `auto` for the loop's lifetime, single-flight so overlapping taps can't leak the override past the helper.

This PR fixes all four: nav stays as a continuation of the section behind it (no white-on-black flip), closes/anchor-taps land without a visible smooth-scroll animation from `y=0`, the external list + footer match the brand's editorial-lowercase + wordmark vocabulary, and the section scroll runs at a deliberate-but-not-sluggish constant pace.

## Notable mechanics

### Nav elevation
- **`data-mobile-open` on `<nav>`** (driven by the `mobileOpen` state already wired through `MobileMenu`'s `onOpenChange`) gives the CSS a single tight selector for the drawer-open visual state, without overloading `data-tone`.
- **`z-index: 58`** lifts the nav above the overlay's `z-55` but leaves it below the panel's `z-60`, so the panel still covers most of the nav from the right and the overlay no longer dims the visible left strip.
- **Backdrop-filter cleared, background painted opaque** in the section's tone (`var(--paper)` on paper sections, `var(--ink)` on ink) — section content can't bleed through the visible strip.
- **Hairline border-bottom matched to the scrolled-state values** (24% ink on paper, 26% paper on ink) for a deliberately demarcated bottom edge.
- **Soft drop shadow** is the cue that actually gives the band weight — without it, opaque paper nav on a paper section reads as no nav at all. Tone-adapted: ink shadow on paper sections, paper glow on ink sections.
- **`box-shadow` and `border-bottom-color` added to both the base and `prefers-reduced-motion` transition lists** so the shadow and hairline fade alongside the drawer's open animation under both motion preferences.

### Scroll-restore on close
- **`<html>` `scroll-behavior` temporarily swapped to `auto`** around a synchronous two-arg `scrollTo(0, scrollYRef)` in the close-effect cleanup. Doesn't use `behavior: "instant"` because Safari only honoured the `"instant"` enum from 18.4; older versions silently fell back to `"auto"` which still respected CSS smooth-scroll — i.e. the original bug. The CSS-swap pattern is universally synchronous regardless of how the enum is interpreted.
- **Restore is gated on "staying on this page"** (no anchor, or anchor with target on the current route). If the drawer was opened from `/blog/<slug>` and the user taps a section row, the local restore is skipped and `window.location.assign('/#section')` is used so the new page handles the hash scroll deterministically — Next 16 App Router's hash-on-soft-nav under `output: "export"` isn't documented; a full reload is the safe bet.
- The result: close via × / overlay / ESC stays exactly where the user opened the drawer (zero scroll). Tapping a section row reads as a clean ride from the prior position to the target, not a jump-to-top + descent.

### Section-anchor scroll
- **`scrollToAnchor` helper at module level** runs a rAF loop at constant velocity (`t`, not eased) over 600ms — slower than the browser default but linear, so there's no high-velocity burst followed by a slow tail.
- **The helper owns its own `<html>` `scroll-behavior` swap** (sets `auto` before the first frame, restores at completion). Without this, per-frame `window.scrollTo` defers to `motion-safe:scroll-smooth` and queues a fresh browser smooth-scroll every tick, fighting the rAF and producing visibly uneven velocity.
- **Single-flight via module-scope state** — a new call cancels any in-flight rAF and eagerly restores its captured `prevScrollBehavior` before snapshotting a fresh one. Prevents the failure mode where overlapping calls capture the already-polluted `"auto"` as "previous" and strand `<html>` permanently at `scroll-behavior: auto`.
- **Respects `scroll-margin-top`** via `getComputedStyle`, so the existing `Frame`'s `scroll-mt-[var(--nav-h)]` keeps working without changes.
- **Reduced-motion path** falls back to `scrollIntoView({ block: "start" })`, which honours `prefers-reduced-motion` automatically (jumps instantly).

### Typography polish
- **`EXTERNAL` labels lowercased** to `docs / blog / litepaper`, matching the editorial-lowercase section rows above them in the drawer. Desktop right cluster keeps Title-Case source — `.meta`'s `text-transform: uppercase` makes the rendered output identical either way.
- **Footer changed from `decdn / labs` → `decdn_labs`** with the `_` painted `text-whisper` and `aria-hidden` so screen readers announce "decdn labs" without an "underscore" artefact. `.meta` uppercases and tracks the source to `D E C D N _ L A B S`, with just the underscore highlighted in green — echoing the wordmark's brand mark instead of an arbitrary slash separator.

## Test plan

### Nav elevation
- [ ] At `<md` viewport, open the drawer on `intro` (paper section): nav reads as a paper band with a 24% ink hairline and a soft ink shadow underneath, distinct from the dimmed page below.
- [ ] Open on `compare` or `faq` (ink sections): nav reads as a black band with a 26% paper hairline and a paper glow underneath. Tone is NOT inverted to match the drawer.
- [ ] Open at the top of the page (not scrolled) AND mid-page (scrolled, where the existing translucent paper backdrop applies): the drawer-open visual wins regardless of scroll state.
- [ ] Drawer slide-in (720ms): the nav shadow fades in (360ms) within the same beat — no snap.
- [ ] Close: shadow fades out smoothly.
- [ ] Resize past 768px with drawer open: `data-mobile-open` clears, nav reverts to its section-tracked behaviour.
- [ ] Reduced motion (`prefers-reduced-motion: reduce`): nav background, border, and shadow still transition (the `prefers-reduced-motion` block's transition list now includes `border-bottom-color` and `box-shadow`); other chrome transitions remain disabled.

### Scroll-restore on close
- [ ] Close via × / overlay / ESC on `/`: page stays exactly at the pre-open scroll position. Zero visible scroll.
- [ ] Tap a section row while on `/`: drawer closes and the page rides from the prior position to the target at constant velocity over 600ms.
- [ ] Tap a section row while on `/blog/<slug>`: full reload to `/#section`; the new page handles the hash scroll on load.
- [ ] Safari < 18.4 (or iOS 17): the close path stays put regardless of the `<html>` smooth-scroll setting — the CSS swap kicks in and the legacy two-arg `scrollTo` lands instantly.

### Section-anchor scroll
- [ ] Tap a section row from anywhere on `/`: scroll is linear (constant pixels-per-millisecond) over 600ms — no perceptible easing.
- [ ] Tap section A, reopen drawer, tap section B before A's scroll completes: B's scroll cancels A's, no permanent override of `<html>`'s `scroll-behavior` (verify via DevTools that `html.style.scrollBehavior` returns to `""` after the second scroll finishes).
- [ ] Reduced motion: tap lands at the target instantly.

### Typography polish
- [ ] Open drawer: external list rows read `docs`, `blog`, `litepaper` (lowercase, same visual weight as the section rows).
- [ ] Footer: `DECDN_LABS` with the `_` character rendered in whisper green; letter-spacing applies uniformly across all characters incl. the underscore.
- [ ] Screen reader on the footer: announces "decdn labs" (not "decdn underscore labs") — the `_` span carries `aria-hidden`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)