### PR TITLE
fix(nav): extend mobile drawer through tablet widths

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1090,9 +1090,8 @@ a.underline-brutal:hover .arrow {
   transform: translate3d(0, 0, 0);
 }
 
-/* Tablet widths up to the desktop gate (1280px) get a wider panel.
-   The clamp floor matches the phone cap (380px) so the panel never
-   shrinks across the 768px crossover. */
+/* Floor matches the phone cap (380px) so the panel never shrinks
+   across the 768px crossover. */
 @media (min-width: 768px) {
   .mm-panel {
     width: clamp(380px, 48vw, 520px);

--- a/app/globals.css
+++ b/app/globals.css
@@ -1090,6 +1090,15 @@ a.underline-brutal:hover .arrow {
   transform: translate3d(0, 0, 0);
 }
 
+/* Tablet widths up to the desktop gate (1280px) get a wider panel.
+   The clamp floor matches the phone cap (380px) so the panel never
+   shrinks across the 768px crossover. */
+@media (min-width: 768px) {
+  .mm-panel {
+    width: clamp(380px, 48vw, 520px);
+  }
+}
+
 .mm-head {
   display: flex;
   align-items: center;
@@ -1237,10 +1246,10 @@ a.underline-brutal:hover .arrow {
   }
 }
 
-/* Phones only. Gated in CSS instead of Tailwind's md:hidden because
+/* Phones and tablets. Gated in CSS instead of Tailwind's xl:hidden because
    these custom rules are unlayered and would beat the utilities layer,
    leaking the toggle onto desktop. */
-@media (min-width: 768px) {
+@media (min-width: 1280px) {
   .mm-toggle,
   .mm-overlay,
   .mm-panel {

--- a/components/site/Chrome.tsx
+++ b/components/site/Chrome.tsx
@@ -166,7 +166,7 @@ export function Chrome() {
           <span className="meta hidden opacity-70 sm:inline">labs</span>
         </Link>
 
-        <ul className="hidden items-center gap-7 md:flex">
+        <ul className="hidden items-center gap-7 xl:flex">
           {NAV.map((item) => {
             const isActive = active === item.id;
             return (
@@ -187,14 +187,14 @@ export function Chrome() {
         <div className="col-start-3 flex items-center gap-5 justify-self-end">
           <a
             href={links.docs}
-            className="meta hidden items-center gap-2 no-underline border-b border-current pb-[2px] md:flex"
+            className="meta hidden items-center gap-2 no-underline border-b border-current pb-[2px] xl:flex"
           >
             <span>Docs</span>
             <span aria-hidden>→</span>
           </a>
           <Link
             href={links.blog}
-            className="meta hidden items-center gap-2 no-underline border-b border-current pb-[2px] md:flex"
+            className="meta hidden items-center gap-2 no-underline border-b border-current pb-[2px] xl:flex"
           >
             <span>Blog</span>
             <span aria-hidden>→</span>
@@ -203,7 +203,7 @@ export function Chrome() {
             href={links.litepaper}
             target="_blank"
             rel="noopener noreferrer"
-            className="meta hidden items-center gap-2 no-underline md:flex"
+            className="meta hidden items-center gap-2 no-underline xl:flex"
             style={{ borderBottom: "1px solid currentColor", paddingBottom: 2 }}
           >
             <span>Litepaper</span>

--- a/components/site/Chrome.tsx
+++ b/components/site/Chrome.tsx
@@ -203,8 +203,7 @@ export function Chrome() {
             href={links.litepaper}
             target="_blank"
             rel="noopener noreferrer"
-            className="meta hidden items-center gap-2 no-underline xl:flex"
-            style={{ borderBottom: "1px solid currentColor", paddingBottom: 2 }}
+            className="meta hidden items-center gap-2 no-underline border-b border-current pb-[2px] xl:flex"
           >
             <span>Litepaper</span>
             <span aria-hidden>→</span>

--- a/components/site/MobileMenu.tsx
+++ b/components/site/MobileMenu.tsx
@@ -249,9 +249,9 @@ export function MobileMenu({ activeSection, tone, onOpenChange }: Props) {
     wasOpenRef.current = open;
   }, [open]);
 
-  // Close on resize to desktop. Without this the CSS hides the panel
-  // but `open` stays true, leaving body scroll locked and the nav
-  // stuck in forced-paper tone.
+  // Close on resize to desktop (≥1280px, matches the CSS gate).
+  // Without this the CSS hides the panel but `open` stays true,
+  // leaving body scroll locked and the nav stuck in forced-paper tone.
   useEffect(() => {
     const mql = window.matchMedia("(min-width: 1280px)");
     const onChange = (e: MediaQueryListEvent) => {

--- a/components/site/MobileMenu.tsx
+++ b/components/site/MobileMenu.tsx
@@ -253,7 +253,7 @@ export function MobileMenu({ activeSection, tone, onOpenChange }: Props) {
   // but `open` stays true, leaving body scroll locked and the nav
   // stuck in forced-paper tone.
   useEffect(() => {
-    const mql = window.matchMedia("(min-width: 768px)");
+    const mql = window.matchMedia("(min-width: 1280px)");
     const onChange = (e: MediaQueryListEvent) => {
       if (e.matches) setOpen(false);
     };


### PR DESCRIPTION
## Summary

- Lifts the drawer gate from `768px` → `1280px` so iPad portrait and similar tablet/small-laptop widths get the mobile drawer instead of the crowded desktop nav.
- Scales `.mm-panel` width to `clamp(380px, 48vw, 520px)` above 768px so tablets get a proportional panel. The clamp floor matches the phone cap, so the panel never shrinks at the 768px crossover.
- Updates `matchMedia` in `MobileMenu.tsx` and `md:flex` → `xl:flex` in `Chrome.tsx` so JS + Tailwind utilities track the new CSS gate.

### Follow-up polish (fd745a1)

- `Chrome.tsx` — Litepaper anchor moved from inline `style` to `border-b border-current pb-[2px]` so it matches Docs/Blog character-for-character (Gemini review consistency note).
- `globals.css` — tightened the new tablet panel-width comment to just the WHY (floor-matching, crossover shrink prevention).
- `MobileMenu.tsx` — `matchMedia` comment now records the `≥1280px` threshold so a reader can grep it against the CSS gate.

Closes #91.

## Test plan

- [ ] DevTools responsive walk: 375 / 767 / 768 / 1024 / 1194 / 1279 / 1280 — drawer visible up to 1279, desktop nav visible at 1280+
- [ ] Panel width: 380px at 767 and 768 (no shrink), ~491px at 1024, 520px from ~1083px through 1279
- [ ] Open drawer at ~900px, drag window past 1280 — drawer auto-closes (matchMedia listener)
- [ ] Open drawer mid-tablet, close — page scroll position restored
- [ ] Tab through drawer — focus trapped to panel
- [x] iPad portrait/landscape simulator if available
- [x] `pnpm lint` and `pnpm build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)