### PR TITLE
feat(comparison): re-quoting legacy price ticker

### DIFF
--- a/components/site/Comparison.tsx
+++ b/components/site/Comparison.tsx
@@ -1,3 +1,4 @@
+import { LegacyPriceTicker } from "@/components/site/LegacyPriceTicker";
 import { ComparisonRow } from "@/components/ui/ComparisonRow";
 import { Frame } from "@/components/ui/Frame";
 import { SectionHeader } from "@/components/ui/SectionHeader";
@@ -69,15 +70,13 @@ export function Comparison() {
                   lineHeight: "0.96",
                 }}
               >
-                <span className="opacity-55">
-                  $0.085–$0.17
-                  <span className="meta ml-1 align-baseline opacity-70">
-                    /GB
-                  </span>
-                </span>
+                <LegacyPriceTicker />
+                {/* opaque mid-gray = paper@55% over the ink section bg, so it
+                    reads as the same color as the dimmed digits without the
+                    lighter banding a semi-transparent bar leaves over glyphs. */}
                 <span
                   aria-hidden
-                  className="absolute inset-x-0 top-1/2 h-[2px] -translate-y-1/2 bg-paper @xl:h-[4px]"
+                  className="absolute inset-x-0 top-1/2 h-[2px] -translate-y-1/2 bg-[color-mix(in_srgb,var(--paper)_55%,var(--ink))] @xl:h-[4px]"
                 />
               </div>
             </div>

--- a/components/site/LegacyPriceTicker.tsx
+++ b/components/site/LegacyPriceTicker.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const MIN = 0.02;
+const MAX = 0.1;
+const SPAN = MAX - MIN;
+/** Minimum gap between consecutive quotes so every re-quote is visibly different. */
+const MIN_STEP = 0.012;
+
+const HOLD_MIN_MS = 900;
+const HOLD_JITTER_MS = 500;
+
+/** A fresh 3-decimal quote in [MIN, MAX], at least MIN_STEP away from `prev`. */
+function nextQuote(prev: number): number {
+  let next = prev;
+  // Terminates fast: only a thin band around `prev` is ever rejected.
+  while (Math.abs(next - prev) < MIN_STEP) {
+    next = Math.round((MIN + Math.random() * SPAN) * 1000) / 1000;
+  }
+  return next;
+}
+
+/**
+ * Legacy CDN price as a never-settling quote: holds a value for ~1s, then snaps
+ * to a new one in $0.02–$0.10 — the volatile foil to deCDN's flat $0.01 in the
+ * comparison table. Mirrors HeroTerminal's pattern: a deterministic first paint
+ * (also the no-JS / static-export value) so hydration matches, with the timer
+ * started in an effect and reduced motion respected.
+ */
+export function LegacyPriceTicker() {
+  // 0.085 is in range and a wink at the copy this replaced ("$0.085–$0.17").
+  const [value, setValue] = useState(0.085);
+
+  useEffect(() => {
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+
+    let holdId: number;
+    const tick = () => {
+      setValue(nextQuote);
+      holdId = window.setTimeout(
+        tick,
+        HOLD_MIN_MS + Math.random() * HOLD_JITTER_MS,
+      );
+    };
+    holdId = window.setTimeout(
+      tick,
+      HOLD_MIN_MS + Math.random() * HOLD_JITTER_MS,
+    );
+    return () => window.clearTimeout(holdId);
+  }, []);
+
+  return (
+    <>
+      <span aria-hidden className="opacity-55">
+        {`$${value.toFixed(3)}`}
+        <span className="meta ml-1 align-baseline opacity-70">/GB</span>
+      </span>
+      <span className="sr-only">approximately $0.02 to $0.10 per gigabyte</span>
+    </>
+  );
+}


### PR DESCRIPTION
## What

Replaces the static, struck-through legacy CDN price range (`$0.085–$0.17 /GB`) in the **02 · Side by side** comparison with a single number that re-quotes itself: it holds for ~1s, then snaps to a fresh value in `$0.020–$0.100 /GB`. The point is contrast — legacy pricing reads as volatile and opaque next to deCDN's rock-steady `$0.01 /GB`.

## How

- **New** `components/site/LegacyPriceTicker.tsx` — a `"use client"` widget in the same family as `HeroTerminal`/`FleetStatus`:
  - Deterministic first paint of `$0.085 /GB` (also the no-JS / static-export value, and a wink at the copy it replaced) → no hydration mismatch.
  - Recursive `setTimeout` (~0.9–1.4s, varied) picks a new 3-decimal quote at least `0.012` away from the last so every change is visible.
  - Honors `prefers-reduced-motion`: stays pinned at `$0.085 /GB`, no ticking.
  - Animated digits are `aria-hidden`; an `sr-only` "approximately $0.02 to $0.10 per gigabyte" carries the meaning.
  - Width never shifts — `.hug` on the parent supplies `tabular-nums` and `toFixed(3)` is always 5 chars after `$`.
- **`components/site/Comparison.tsx`** — swaps the static price span for `<LegacyPriceTicker />`; the strikethrough bar is now an opaque mid-gray (`color-mix(in srgb, var(--paper) 55%, var(--ink))`) so it matches the dimmed digits without banding lighter where it crosses the glyphs. The deCDN `$0.01 /GB` cell is untouched.

No CSS-file or `types/css.d.ts` changes (`sr-only`, `meta` already exist; the gray is computed inline from existing tokens).

## Verify

- `pnpm dev` → scroll to **02 · Side by side**: the legacy "price" cell, struck through, re-quotes once a second; width stays put; deCDN stays `$0.01 /GB`.
- OS "reduce motion" on → reload → legacy cell stays at `$0.085 /GB`, no ticking.
- `pnpm lint` ✓ · `pnpm build` (static export) ✓ · `pnpm test` 22/22 ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)