### PR TITLE
feat(blog): redesign the index and post pages as a "field-log" table

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -174,11 +174,20 @@ export default async function BlogPost({
                   href={`/blog/${older.slug}/`}
                   className="group flex flex-col gap-2 no-underline"
                 >
-                  <span className="meta opacity-50">
-                    <span aria-hidden>←</span> earlier
+                  {/* The title holds steady on hover — the glyph slides +
+                      greens and the label lifts, mirroring the index row's
+                      `→`. */}
+                  <span className="meta opacity-50 transition-opacity duration-300 ease-out group-hover:opacity-90">
+                    <span
+                      aria-hidden
+                      className="inline-block transition-all duration-300 ease-out group-hover:-translate-x-1 group-hover:text-whisper"
+                    >
+                      ←
+                    </span>{" "}
+                    earlier
                   </span>
                   <span
-                    className="hug leading-[1.2] font-bold transition-opacity group-hover:opacity-70"
+                    className="hug leading-[1.2] font-bold"
                     style={{ fontSize: "var(--fs-lead)" }}
                   >
                     {older.title}
@@ -192,11 +201,17 @@ export default async function BlogPost({
                   href={`/blog/${newer.slug}/`}
                   className="group flex flex-col gap-2 no-underline @xl:items-end @xl:text-right"
                 >
-                  <span className="meta opacity-50">
-                    later <span aria-hidden>→</span>
+                  <span className="meta opacity-50 transition-opacity duration-300 ease-out group-hover:opacity-90">
+                    later{" "}
+                    <span
+                      aria-hidden
+                      className="inline-block transition-all duration-300 ease-out group-hover:translate-x-1 group-hover:text-whisper"
+                    >
+                      →
+                    </span>
                   </span>
                   <span
-                    className="hug leading-[1.2] font-bold transition-opacity group-hover:opacity-70"
+                    className="hug leading-[1.2] font-bold"
                     style={{ fontSize: "var(--fs-lead)" }}
                   >
                     {newer.title}

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -5,18 +5,11 @@ import { MDXRemote } from "next-mdx-remote/rsc";
 import remarkGfm from "remark-gfm";
 import { Frame } from "@/components/ui/Frame";
 import { Pill } from "@/components/ui/Pill";
+import { META, dottedDate, readLabel } from "@/components/ui/PostRow";
 import { Prose } from "@/components/ui/Prose";
 import { getPost, listPosts } from "@/lib/blog";
 import { JsonLd } from "@/lib/jsonld";
 import { ORG_ID, SITE_URL } from "@/lib/links";
-
-// `2026-05-11` → `2026·05·11` for display; <time dateTime> keeps the
-// machine value.
-const dotted = (iso: string) => iso.replaceAll("-", "·");
-
-// Lowercase meta strip (mirrors components/ui/PostRow) — `.meta` is an
-// unlayered rule that forces uppercase, which we don't want on `08 min`.
-const META = "text-[0.6875rem] leading-[1.3] font-medium tracking-[0.16em]";
 
 // Static export: enumerate every slug at build time and refuse anything
 // outside that set. `dynamicParams = false` mirrors the closed-world
@@ -81,7 +74,7 @@ export default async function BlogPost({
   const older = i < all.length - 1 ? all[i + 1] : undefined;
 
   const tags = post.tags ?? [];
-  const minutes = `${String(post.readMin).padStart(2, "0")} min`;
+  const minutes = readLabel(post.readMin);
 
   const postUrl = `${SITE_URL}blog/${post.slug}/`;
   const postingSchema = {
@@ -123,6 +116,7 @@ export default async function BlogPost({
         <article className="flex flex-col gap-10">
           <Link
             href="/blog/"
+            aria-label="Back to field notes"
             className="meta inline-flex items-center gap-2 self-start opacity-50 no-underline transition-opacity hover:opacity-100"
           >
             <span aria-hidden>←</span> field notes
@@ -134,7 +128,7 @@ export default async function BlogPost({
             >
               <span>§ {num}</span>
               <span aria-hidden>·</span>
-              <time dateTime={post.date}>{dotted(post.date)}</time>
+              <time dateTime={post.date}>{dottedDate(post.date)}</time>
               <span aria-hidden>·</span>
               <span>{minutes}</span>
             </div>

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -82,7 +82,6 @@ export default async function BlogPost({
 
   const tags = post.tags ?? [];
   const minutes = `${String(post.readMin).padStart(2, "0")} min`;
-  const words = `${post.words.toLocaleString("en-US")} wds`;
 
   const postUrl = `${SITE_URL}blog/${post.slug}/`;
   const postingSchema = {
@@ -137,9 +136,7 @@ export default async function BlogPost({
               <span aria-hidden>·</span>
               <time dateTime={post.date}>{dotted(post.date)}</time>
               <span aria-hidden>·</span>
-              <span>
-                {minutes} <span aria-hidden>·</span> {words}
-              </span>
+              <span>{minutes}</span>
             </div>
             <h1
               id="post-h"
@@ -147,9 +144,6 @@ export default async function BlogPost({
               style={{ fontSize: "var(--fs-h2)" }}
             >
               {post.title}
-              <span aria-hidden className="text-whisper">
-                .
-              </span>
             </h1>
             {tags.length > 0 && (
               <ul className="flex flex-wrap gap-2">

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -5,9 +5,15 @@ import { MDXRemote } from "next-mdx-remote/rsc";
 import remarkGfm from "remark-gfm";
 import { Frame } from "@/components/ui/Frame";
 import { Pill } from "@/components/ui/Pill";
-import { META, dottedDate, readLabel } from "@/components/ui/PostRow";
+import { META } from "@/components/ui/PostRow";
 import { Prose } from "@/components/ui/Prose";
-import { getPost, listPosts } from "@/lib/blog";
+import {
+  dottedDate,
+  getPost,
+  listPosts,
+  readLabel,
+  seriesLabel,
+} from "@/lib/blog";
 import { JsonLd } from "@/lib/jsonld";
 import { ORG_ID, SITE_URL } from "@/lib/links";
 
@@ -65,13 +71,12 @@ export default async function BlogPost({
   const post = getPost(slug);
   if (!post) notFound();
 
-  // Position in the series: list is newest-first, so a smaller index is
-  // a *later* post. num counts oldest = 01, matching the index page.
+  // Prev/next: the posts one number above (more recent) and below this
+  // one in the series. `find` returns undefined at the ends.
   const all = listPosts();
-  const i = all.findIndex((p) => p.slug === post.slug);
-  const num = String(all.length - i).padStart(2, "0");
-  const newer = i > 0 ? all[i - 1] : undefined;
-  const older = i < all.length - 1 ? all[i + 1] : undefined;
+  const num = seriesLabel(post.seriesNumber);
+  const newer = all.find((p) => p.seriesNumber === post.seriesNumber + 1);
+  const older = all.find((p) => p.seriesNumber === post.seriesNumber - 1);
 
   const tags = post.tags ?? [];
   const minutes = readLabel(post.readMin);
@@ -169,7 +174,9 @@ export default async function BlogPost({
                   href={`/blog/${older.slug}/`}
                   className="group flex flex-col gap-2 no-underline"
                 >
-                  <span className="meta opacity-50">← earlier</span>
+                  <span className="meta opacity-50">
+                    <span aria-hidden>←</span> earlier
+                  </span>
                   <span
                     className="hug leading-[1.2] font-bold transition-opacity group-hover:opacity-70"
                     style={{ fontSize: "var(--fs-lead)" }}
@@ -185,7 +192,9 @@ export default async function BlogPost({
                   href={`/blog/${newer.slug}/`}
                   className="group flex flex-col gap-2 no-underline @xl:items-end @xl:text-right"
                 >
-                  <span className="meta opacity-50">later →</span>
+                  <span className="meta opacity-50">
+                    later <span aria-hidden>→</span>
+                  </span>
                   <span
                     className="hug leading-[1.2] font-bold transition-opacity group-hover:opacity-70"
                     style={{ fontSize: "var(--fs-lead)" }}

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,12 +1,22 @@
 import type { Metadata, ResolvingMetadata } from "next";
+import Link from "next/link";
 import { notFound } from "next/navigation";
 import { MDXRemote } from "next-mdx-remote/rsc";
 import remarkGfm from "remark-gfm";
 import { Frame } from "@/components/ui/Frame";
+import { Pill } from "@/components/ui/Pill";
 import { Prose } from "@/components/ui/Prose";
 import { getPost, listPosts } from "@/lib/blog";
 import { JsonLd } from "@/lib/jsonld";
 import { ORG_ID, SITE_URL } from "@/lib/links";
+
+// `2026-05-11` → `2026·05·11` for display; <time dateTime> keeps the
+// machine value.
+const dotted = (iso: string) => iso.replaceAll("-", "·");
+
+// Lowercase meta strip (mirrors components/ui/PostRow) — `.meta` is an
+// unlayered rule that forces uppercase, which we don't want on `08 min`.
+const META = "text-[0.6875rem] leading-[1.3] font-medium tracking-[0.16em]";
 
 // Static export: enumerate every slug at build time and refuse anything
 // outside that set. `dynamicParams = false` mirrors the closed-world
@@ -41,6 +51,7 @@ export async function generateMetadata(
       url: `/blog/${post.slug}/`,
       type: "article",
       publishedTime: post.date,
+      tags: post.tags,
       images: ogImages,
     },
     twitter: {
@@ -61,6 +72,18 @@ export default async function BlogPost({
   const post = getPost(slug);
   if (!post) notFound();
 
+  // Position in the series: list is newest-first, so a smaller index is
+  // a *later* post. num counts oldest = 01, matching the index page.
+  const all = listPosts();
+  const i = all.findIndex((p) => p.slug === post.slug);
+  const num = String(all.length - i).padStart(2, "0");
+  const newer = i > 0 ? all[i - 1] : undefined;
+  const older = i < all.length - 1 ? all[i + 1] : undefined;
+
+  const tags = post.tags ?? [];
+  const minutes = `${String(post.readMin).padStart(2, "0")} min`;
+  const words = `${post.words.toLocaleString("en-US")} wds`;
+
   const postUrl = `${SITE_URL}blog/${post.slug}/`;
   const postingSchema = {
     "@context": "https://schema.org",
@@ -72,6 +95,8 @@ export default async function BlogPost({
     url: postUrl,
     mainEntityOfPage: postUrl,
     image: `${SITE_URL}opengraph-image.png`,
+    keywords: post.tags?.join(", "),
+    wordCount: post.words,
     author: { "@id": ORG_ID },
     publisher: { "@id": ORG_ID },
   };
@@ -97,17 +122,44 @@ export default async function BlogPost({
       <JsonLd data={breadcrumbSchema} />
       <Frame id="post" tone="paper">
         <article className="flex flex-col gap-10">
+          <Link
+            href="/blog/"
+            className="meta inline-flex items-center gap-2 self-start opacity-50 no-underline transition-opacity hover:opacity-100"
+          >
+            <span aria-hidden>←</span> field notes
+          </Link>
+
           <header className="flex flex-col gap-6">
-            <time className="meta opacity-60" dateTime={post.date}>
-              {post.date}
-            </time>
+            <div
+              className={`${META} flex flex-wrap items-center gap-x-3 gap-y-1 tabular-nums opacity-50`}
+            >
+              <span>§ {num}</span>
+              <span aria-hidden>·</span>
+              <time dateTime={post.date}>{dotted(post.date)}</time>
+              <span aria-hidden>·</span>
+              <span>
+                {minutes} <span aria-hidden>·</span> {words}
+              </span>
+            </div>
             <h1
               id="post-h"
-              className="hug font-semibold leading-[0.95] tracking-[-0.035em]"
+              className="hug leading-[0.95] font-extrabold"
               style={{ fontSize: "var(--fs-h2)" }}
             >
               {post.title}
+              <span aria-hidden className="text-whisper">
+                .
+              </span>
             </h1>
+            {tags.length > 0 && (
+              <ul className="flex flex-wrap gap-2">
+                {tags.map((tag) => (
+                  <li key={tag}>
+                    <Pill>#{tag}</Pill>
+                  </li>
+                ))}
+              </ul>
+            )}
           </header>
 
           <span aria-hidden className="rule opacity-20" />
@@ -118,6 +170,46 @@ export default async function BlogPost({
               options={{ mdxOptions: { remarkPlugins: [remarkGfm] } }}
             />
           </Prose>
+
+          {(older || newer) && (
+            <nav
+              aria-label="More field notes"
+              className="mt-4 grid gap-6 border-t border-current/15 pt-10 @xl:grid-cols-2 @xl:gap-10"
+            >
+              {older ? (
+                <Link
+                  href={`/blog/${older.slug}/`}
+                  className="group flex flex-col gap-2 no-underline"
+                >
+                  <span className="meta opacity-50">← earlier</span>
+                  <span
+                    className="hug leading-[1.2] font-bold transition-opacity group-hover:opacity-70"
+                    style={{ fontSize: "var(--fs-lead)" }}
+                  >
+                    {older.title}
+                  </span>
+                </Link>
+              ) : (
+                <span aria-hidden className="hidden @xl:block" />
+              )}
+              {newer ? (
+                <Link
+                  href={`/blog/${newer.slug}/`}
+                  className="group flex flex-col gap-2 no-underline @xl:items-end @xl:text-right"
+                >
+                  <span className="meta opacity-50">later →</span>
+                  <span
+                    className="hug leading-[1.2] font-bold transition-opacity group-hover:opacity-70"
+                    style={{ fontSize: "var(--fs-lead)" }}
+                  >
+                    {newer.title}
+                  </span>
+                </Link>
+              ) : (
+                <span aria-hidden className="hidden @xl:block" />
+              )}
+            </nav>
+          )}
         </article>
       </Frame>
     </main>

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -140,7 +140,7 @@ export default async function BlogPost({
             </div>
             <h1
               id="post-h"
-              className="hug leading-[0.95] font-extrabold"
+              className="hug leading-[0.95] font-bold"
               style={{ fontSize: "var(--fs-h2)" }}
             >
               {post.title}

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -59,15 +59,9 @@ export default function BlogIndex() {
       <JsonLd data={breadcrumbSchema} />
       <Frame id="blog" tone="paper">
         <header className="flex flex-col gap-6">
-          {/* .rise forces opacity:1 at rest (fill: forwards), so the
-              dimmed label/lead sit inside .rise wrappers rather than
-              carrying the class themselves. */}
-          <div className="rise rise-0">
-            <span className="meta opacity-60">field notes</span>
-          </div>
           <h1
             id="blog-h"
-            className="hug rise rise-1 leading-[0.92] font-extrabold"
+            className="hug rise rise-0 leading-[0.92] font-bold"
             style={{ fontSize: "var(--fs-h2)" }}
           >
             field notes
@@ -75,7 +69,10 @@ export default function BlogIndex() {
               _
             </span>
           </h1>
-          <div className="rise rise-2">
+          {/* .rise forces opacity:1 at rest (fill: forwards), so the
+              dimmed lead sits inside a .rise wrapper rather than carrying
+              the class itself. */}
+          <div className="rise rise-1">
             <p
               className="max-w-[60ch] leading-[1.7] opacity-75"
               style={{ fontSize: "var(--fs-lead)" }}

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -112,7 +112,6 @@ export default function BlogIndex() {
                 <PostRow
                   key={post.slug}
                   post={post}
-                  num={String(posts.length - i).padStart(2, "0")}
                   delay={Math.min(i, 4) * 80}
                 />
               ))}

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata, ResolvingMetadata } from "next";
-import Link from "next/link";
 import { Frame } from "@/components/ui/Frame";
+import { BLOG_GRID_COLS, PostRow } from "@/components/ui/PostRow";
 import { listPosts } from "@/lib/blog";
 import { JsonLd } from "@/lib/jsonld";
 import { SITE_URL } from "@/lib/links";
@@ -59,66 +59,68 @@ export default function BlogIndex() {
       <JsonLd data={breadcrumbSchema} />
       <Frame id="blog" tone="paper">
         <header className="flex flex-col gap-6">
-          <span className="meta opacity-60">field notes</span>
+          {/* .rise forces opacity:1 at rest (fill: forwards), so the
+              dimmed label/lead sit inside .rise wrappers rather than
+              carrying the class themselves. */}
+          <div className="rise rise-0">
+            <span className="meta opacity-60">field notes</span>
+          </div>
           <h1
             id="blog-h"
-            className="hug font-semibold leading-[0.92] tracking-[-0.04em]"
+            className="hug rise rise-1 leading-[0.92] font-extrabold"
             style={{ fontSize: "var(--fs-h2)" }}
           >
-            field notes.
+            field notes
+            <span aria-hidden className="text-whisper">
+              .
+            </span>
           </h1>
-          <p
-            className="max-w-[60ch] leading-[1.7] opacity-75"
-            style={{ fontSize: "var(--fs-lead)" }}
-          >
-            long-form posts on the deCDN protocol — what it is, why now, and how
-            the pieces fit together. published when something&apos;s worth
-            saying.
-          </p>
+          <div className="rise rise-2">
+            <p
+              className="max-w-[60ch] leading-[1.7] opacity-75"
+              style={{ fontSize: "var(--fs-lead)" }}
+            >
+              long-form posts on the deCDN protocol — what it is, why now, and
+              how the pieces fit together. published when something&apos;s worth
+              saying.
+            </p>
+          </div>
         </header>
 
-        <span aria-hidden className="rule mt-16 opacity-20" />
-
         {posts.length === 0 ? (
-          <p
-            className="mt-16 opacity-60"
-            style={{ fontSize: "var(--fs-body)" }}
-          >
-            nothing yet.
-          </p>
+          <>
+            <span aria-hidden className="rule mt-16 opacity-20" />
+            <p
+              className="mt-16 opacity-60"
+              style={{ fontSize: "var(--fs-body)" }}
+            >
+              nothing yet.
+            </p>
+          </>
         ) : (
-          <ul className="mt-16 flex flex-col divide-y divide-current/15">
-            {posts.map((post) => (
-              <li key={post.slug}>
-                <Link
-                  href={`/blog/${post.slug}/`}
-                  className="group grid gap-2 py-8 no-underline @xl:grid-cols-[10rem_1fr] @xl:gap-10"
-                >
-                  <time
-                    className="meta opacity-60"
-                    dateTime={post.date}
-                    style={{ alignSelf: "start" }}
-                  >
-                    {post.date}
-                  </time>
-                  <div className="flex flex-col gap-3">
-                    <h2
-                      className="hug font-semibold leading-[1.05] tracking-[-0.025em] group-hover:opacity-80"
-                      style={{ fontSize: "var(--fs-h3)" }}
-                    >
-                      {post.title}
-                    </h2>
-                    <p
-                      className="max-w-[60ch] leading-[1.6] opacity-75"
-                      style={{ fontSize: "var(--fs-body)" }}
-                    >
-                      {post.summary}
-                    </p>
-                  </div>
-                </Link>
-              </li>
-            ))}
-          </ul>
+          <div className="mt-16 flex flex-col">
+            <div
+              aria-hidden
+              className={`meta hidden pb-3 opacity-50 @xl:grid ${BLOG_GRID_COLS}`}
+            >
+              <span>#</span>
+              <span>date</span>
+              <span>title · summary</span>
+              <span className="text-right">read</span>
+              <span />
+            </div>
+            <span aria-hidden className="rule rule-2" />
+            <ul className="flex flex-col divide-y divide-current/12">
+              {posts.map((post, i) => (
+                <PostRow
+                  key={post.slug}
+                  post={post}
+                  num={String(posts.length - i).padStart(2, "0")}
+                  delay={Math.min(i, 4) * 80}
+                />
+              ))}
+            </ul>
+          </div>
         )}
       </Frame>
     </main>

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -72,7 +72,7 @@ export default function BlogIndex() {
           >
             field notes
             <span aria-hidden className="text-whisper">
-              .
+              _
             </span>
           </h1>
           <div className="rise rise-2">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,7 +10,9 @@ import "./globals.css";
 const geistSans = Geist({
   variable: "--font-geist-sans",
   subsets: ["latin"],
-  weight: ["400", "500", "600", "700"],
+  // 800 powers the blog "field-log" display titles (font-extrabold);
+  // everything else uses 400–700.
+  weight: ["400", "500", "600", "700", "800"],
 });
 
 const TITLE = "deCDN — A peer-to-peer delivery layer for bytes at scale";

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,9 +10,7 @@ import "./globals.css";
 const geistSans = Geist({
   variable: "--font-geist-sans",
   subsets: ["latin"],
-  // 800 powers the blog "field-log" display titles (font-extrabold);
-  // everything else uses 400–700.
-  weight: ["400", "500", "600", "700", "800"],
+  weight: ["400", "500", "600", "700"],
 });
 
 const TITLE = "deCDN — A peer-to-peer delivery layer for bytes at scale";

--- a/components/site/Chrome.tsx
+++ b/components/site/Chrome.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { links } from "@/lib/links";
 import { MobileMenu } from "@/components/site/MobileMenu";
 
@@ -30,6 +31,12 @@ export function Chrome() {
   const [scrolled, setScrolled] = useState(false);
   const [mobileOpen, setMobileOpen] = useState(false);
   const navRef = useRef<HTMLElement>(null);
+  // This component lives in the root layout, so a `next/link` client-side
+  // nav swaps the page DOM without remounting it. Keying the observers on
+  // `pathname` lets them re-bind to the new route's sections — otherwise,
+  // after navigating to /blog/* and back, `active` (and the nav tone that
+  // tracks it) would stay frozen at its last home-page value.
+  const pathname = usePathname();
 
   const handleMobileOpenChange = useCallback(
     (open: boolean) => setMobileOpen(open),
@@ -43,8 +50,9 @@ export function Chrome() {
   // nav, so the tone flip happens exactly when its top crosses under.
   //
   // The slice depends on window.innerHeight AND navbar.offsetHeight, so
-  // the IO is rebuilt on (a) window resize and (b) nav-size changes
-  // (e.g. webfont swap). Rebuilds are rAF-coalesced so a resize burst
+  // the IO is rebuilt on (a) route change (the section nodes themselves
+  // change), (b) window resize and (c) nav-size changes (e.g. webfont
+  // swap). Rebuilds are rAF-coalesced so a resize burst
   // collapses to one rebuild per frame. When two adjacent sections
   // share the slice (subpixel rounding at boundaries), we pick the
   // entry with the largest boundingClientRect.top — the section whose
@@ -107,14 +115,17 @@ export function Chrome() {
       ro?.disconnect();
       io?.disconnect();
     };
-  }, []);
+  }, [pathname]);
 
   useEffect(() => {
     const onScroll = () => setScrolled(window.scrollY > 8);
+    // Re-sync after a client-side nav too: the route change resets scroll
+    // to the top, but a `[]`-deps effect wouldn't re-read it, leaving
+    // `data-scrolled` stale on the new page until the next scroll event.
     onScroll();
     window.addEventListener("scroll", onScroll, { passive: true });
     return () => window.removeEventListener("scroll", onScroll);
-  }, []);
+  }, [pathname]);
 
   const onDark = DARK_SECTIONS.has(active);
   // The toggle is portalled to <body> (see MobileMenu.tsx) and lives

--- a/components/site/ScrollReveal.tsx
+++ b/components/site/ScrollReveal.tsx
@@ -1,8 +1,20 @@
 "use client";
 
 import { useEffect } from "react";
+import { usePathname } from "next/navigation";
 
 export function ScrollReveal() {
+  // Re-run on path change: this component lives in the root layout (which
+  // never remounts and has no template.tsx), so a `next/link` client-side
+  // nav swaps the page DOM without re-firing a `[]`-deps effect — the new
+  // route's `[data-reveal]` nodes would never get observed and would sit
+  // at opacity:0 on browsers that fall back to this observer (Firefox,
+  // Safari < 26; the modern path is the CSS `animation-timeline: view()`
+  // in globals.css). Effects run after the new DOM is committed, so the
+  // re-run query picks the new nodes up. Hash-only links (`/#compare`)
+  // leave `pathname` unchanged, so they don't trigger a needless rebuild.
+  const pathname = usePathname();
+
   useEffect(() => {
     const els = document.querySelectorAll<HTMLElement>("[data-reveal]");
     if (els.length === 0) return;
@@ -21,7 +33,7 @@ export function ScrollReveal() {
 
     els.forEach((el) => io.observe(el));
     return () => io.disconnect();
-  }, []);
+  }, [pathname]);
 
   return null;
 }

--- a/components/ui/Pill.tsx
+++ b/components/ui/Pill.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from "react";
+
+/**
+ * Small bordered label used for blog tags (e.g. `#transport`). Inert by
+ * design — blog rows are wrapped in a single <Link>, so a nested anchor
+ * here would be invalid; tag-filter pages can promote these to links
+ * later if that lands. (We don't reuse the `.meta` class because it's an
+ * unlayered rule that forces uppercase — tags read lowercase.)
+ */
+export function Pill({ children }: { children: ReactNode }) {
+  return (
+    <span className="inline-flex items-center rounded border border-current/25 px-2 py-1 text-[0.6875rem] leading-none font-medium tracking-[0.06em] opacity-55">
+      {children}
+    </span>
+  );
+}

--- a/components/ui/PostRow.tsx
+++ b/components/ui/PostRow.tsx
@@ -1,39 +1,26 @@
 import Link from "next/link";
 import type { PostMeta } from "@/lib/blog";
+import { dottedDate, readLabel, seriesLabel } from "@/lib/blog";
 import { Pill } from "./Pill";
 
 // Shared 5-track grid for the index "field-log" table — `#` · date ·
 // title/summary · read · arrow. The column-header row in app/blog/page.tsx
-// uses the same tracks so labels line up over their columns. `minmax(0,1fr)`
-// lets the title column shrink (titles carry hard hyphens) instead of
-// pushing the grid wider than its container.
+// uses the same tracks so the labels line up over their columns.
+// `minmax(0,1fr)` (rather than plain `1fr`) lets the title column shrink
+// below its content's intrinsic width instead of pushing the grid past
+// its container — a long unbroken title can't blow out the layout.
 export const BLOG_GRID_COLS =
   "@xl:grid-cols-[2.5rem_7.5rem_minmax(0,1fr)_6.5rem_1.5rem] @xl:gap-x-8";
 
-// `2026-05-11` → `2026·05·11` — the field-log date style. The machine
-// value stays in <time dateTime>; only the display string gets the dots.
-// Shared with the post page (app/blog/[slug]/page.tsx).
-export const dottedDate = (iso: string) => iso.replaceAll("-", "·");
-
-// `08 min` — zero-padded read estimate. Shared with the post page.
-export const readLabel = (min: number) => `${String(min).padStart(2, "0")} min`;
-
-// Lowercase meta (11px, tracked, tabular figures) — like `.meta` but
-// without its forced uppercase, since `02 · 08 min` reads lowercase.
-// `.meta` is an unlayered rule we can't override per-call. Shared with
-// the post page.
+// Lowercase meta text — like `.meta` but without its forced uppercase
+// (`02 · 08 min` reads lowercase) and at a tighter tracking. `.meta` is
+// an unlayered rule we can't override per-call. Bakes in `tabular-nums`
+// so figures align down the column. Shared with the post page.
 export const META =
-  "text-[0.6875rem] leading-[1.3] font-medium tracking-[0.16em]";
+  "text-[0.6875rem] leading-[1.3] font-medium tracking-[0.16em] tabular-nums";
 
-export function PostRow({
-  post,
-  num,
-  delay,
-}: {
-  post: PostMeta;
-  num: string;
-  delay: number;
-}) {
+export function PostRow({ post, delay }: { post: PostMeta; delay: number }) {
+  const num = seriesLabel(post.seriesNumber);
   const minutes = readLabel(post.readMin);
   const date = dottedDate(post.date);
   const tags = post.tags ?? [];
@@ -46,7 +33,7 @@ export function PostRow({
       >
         {/* mobile-only meta line */}
         <div
-          className={`${META} flex items-baseline justify-between gap-4 tabular-nums opacity-50 @xl:hidden`}
+          className={`${META} flex items-baseline justify-between gap-4 opacity-50 @xl:hidden`}
         >
           <span>
             {num} <span aria-hidden>·</span>{" "}
@@ -57,7 +44,7 @@ export function PostRow({
 
         {/* # */}
         <span
-          className={`${META} hidden self-start tabular-nums opacity-35 @xl:mt-1.5 @xl:block`}
+          className={`${META} hidden self-start opacity-35 @xl:mt-1.5 @xl:block`}
         >
           {num}
         </span>
@@ -65,7 +52,7 @@ export function PostRow({
         {/* date */}
         <time
           dateTime={post.date}
-          className={`${META} hidden self-start tabular-nums opacity-55 @xl:mt-1.5 @xl:block`}
+          className={`${META} hidden self-start opacity-55 @xl:mt-1.5 @xl:block`}
         >
           {date}
         </time>
@@ -106,7 +93,7 @@ export function PostRow({
 
         {/* read */}
         <div
-          className={`${META} hidden self-start tabular-nums @xl:mt-1.5 @xl:block @xl:text-right`}
+          className={`${META} hidden self-start @xl:mt-1.5 @xl:block @xl:text-right`}
         >
           {minutes}
         </div>

--- a/components/ui/PostRow.tsx
+++ b/components/ui/PostRow.tsx
@@ -66,7 +66,7 @@ export function PostRow({
         {/* title · summary · tags */}
         <div className="flex flex-col gap-3">
           <h2
-            className="hug leading-[1.05] font-extrabold transition-opacity group-hover:opacity-80"
+            className="hug leading-[1.05] font-bold transition-opacity group-hover:opacity-80"
             style={{ fontSize: "var(--fs-h3)" }}
           >
             {post.title}

--- a/components/ui/PostRow.tsx
+++ b/components/ui/PostRow.tsx
@@ -1,0 +1,113 @@
+import Link from "next/link";
+import type { PostMeta } from "@/lib/blog";
+import { Pill } from "./Pill";
+
+// Shared 5-track grid for the index "field-log" table — `#` · date ·
+// title/summary · read · arrow. The column-header row in app/blog/page.tsx
+// uses the same tracks so labels line up over their columns. `minmax(0,1fr)`
+// lets the title column shrink (titles carry hard hyphens) instead of
+// pushing the grid wider than its container.
+export const BLOG_GRID_COLS =
+  "@xl:grid-cols-[2.5rem_7.5rem_minmax(0,1fr)_6.5rem_1.5rem] @xl:gap-x-8";
+
+// `2026-05-11` → `2026·05·11` — the field-log date style. The machine
+// value stays in <time dateTime>; only the display string gets the dots.
+const dotted = (iso: string) => iso.replaceAll("-", "·");
+
+// Lowercase meta (11px, tracked, tabular figures) — like `.meta` but
+// without its forced uppercase, since `02 · 08 min · 1,920 wds` read
+// lowercase. `.meta` is an unlayered rule we can't override per-call.
+const META = "text-[0.6875rem] leading-[1.2] font-medium tracking-[0.16em]";
+
+export function PostRow({
+  post,
+  num,
+  delay,
+}: {
+  post: PostMeta;
+  num: string;
+  delay: number;
+}) {
+  const minutes = `${String(post.readMin).padStart(2, "0")} min`;
+  const words = `${post.words.toLocaleString("en-US")} wds`;
+  const tags = post.tags ?? [];
+
+  return (
+    <li data-reveal style={{ "--reveal-delay": `${delay}ms` }}>
+      <Link
+        href={`/blog/${post.slug}/`}
+        className={`group grid gap-4 py-8 no-underline @xl:py-9 ${BLOG_GRID_COLS}`}
+      >
+        {/* mobile-only meta line */}
+        <div
+          className={`${META} flex items-baseline justify-between gap-4 tabular-nums opacity-50 @xl:hidden`}
+        >
+          <span>
+            {num} <span aria-hidden>·</span>{" "}
+            <time dateTime={post.date}>{dotted(post.date)}</time>
+          </span>
+          <span>{minutes}</span>
+        </div>
+
+        {/* # */}
+        <span
+          className={`${META} hidden self-start tabular-nums opacity-35 @xl:mt-1.5 @xl:block`}
+        >
+          {num}
+        </span>
+
+        {/* date */}
+        <time
+          dateTime={post.date}
+          className={`${META} hidden self-start tabular-nums opacity-55 @xl:mt-1.5 @xl:block`}
+        >
+          {dotted(post.date)}
+        </time>
+
+        {/* title · summary · tags */}
+        <div className="flex flex-col gap-3">
+          <h2
+            className="hug leading-[1.05] font-extrabold transition-opacity group-hover:opacity-80"
+            style={{ fontSize: "var(--fs-h3)" }}
+          >
+            {post.title}
+            <span aria-hidden className="text-whisper">
+              .
+            </span>
+          </h2>
+          <p
+            className="max-w-[62ch] leading-[1.6] opacity-75"
+            style={{ fontSize: "var(--fs-body)" }}
+          >
+            {post.summary}
+          </p>
+          {tags.length > 0 && (
+            <ul className="mt-1 flex flex-wrap gap-2">
+              {tags.map((tag) => (
+                <li key={tag}>
+                  <Pill>#{tag}</Pill>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        {/* read */}
+        <div
+          className={`${META} hidden flex-col items-end gap-1 self-start tabular-nums @xl:mt-1.5 @xl:flex`}
+        >
+          <span>{minutes}</span>
+          <span className="opacity-50">{words}</span>
+        </div>
+
+        {/* arrow */}
+        <span
+          aria-hidden
+          className="hidden self-start text-lg leading-none opacity-30 transition-all duration-300 ease-out group-hover:translate-x-1.5 group-hover:text-whisper group-hover:opacity-100 @xl:mt-2 @xl:block @xl:text-right"
+        >
+          →
+        </span>
+      </Link>
+    </li>
+  );
+}

--- a/components/ui/PostRow.tsx
+++ b/components/ui/PostRow.tsx
@@ -29,7 +29,6 @@ export function PostRow({
   delay: number;
 }) {
   const minutes = `${String(post.readMin).padStart(2, "0")} min`;
-  const words = `${post.words.toLocaleString("en-US")} wds`;
   const tags = post.tags ?? [];
 
   return (
@@ -71,9 +70,6 @@ export function PostRow({
             style={{ fontSize: "var(--fs-h3)" }}
           >
             {post.title}
-            <span aria-hidden className="text-whisper">
-              .
-            </span>
           </h2>
           <p
             className="max-w-[62ch] leading-[1.6] opacity-75"
@@ -94,10 +90,9 @@ export function PostRow({
 
         {/* read */}
         <div
-          className={`${META} hidden flex-col items-end gap-1 self-start tabular-nums @xl:mt-1.5 @xl:flex`}
+          className={`${META} hidden self-start tabular-nums @xl:mt-1.5 @xl:block @xl:text-right`}
         >
-          <span>{minutes}</span>
-          <span className="opacity-50">{words}</span>
+          {minutes}
         </div>
 
         {/* arrow */}

--- a/components/ui/PostRow.tsx
+++ b/components/ui/PostRow.tsx
@@ -70,6 +70,15 @@ export function PostRow({
             style={{ fontSize: "var(--fs-h3)" }}
           >
             {post.title}
+            {/* terminal-prompt cursor — echoes the "field notes_" page
+                title; sits invisible (reserving its width so hover never
+                reflows the line) and fades in whisper-green on row hover. */}
+            <span
+              aria-hidden
+              className="text-whisper opacity-0 transition-opacity duration-300 ease-out group-hover:opacity-100"
+            >
+              _
+            </span>
           </h2>
           <p
             className="max-w-[62ch] leading-[1.6] opacity-75"

--- a/components/ui/PostRow.tsx
+++ b/components/ui/PostRow.tsx
@@ -60,13 +60,15 @@ export function PostRow({ post, delay }: { post: PostMeta; delay: number }) {
         {/* title · summary · tags */}
         <div className="flex flex-col gap-3">
           <h2
-            className="hug leading-[1.05] font-bold transition-opacity group-hover:opacity-80"
+            className="hug leading-[1.05] font-bold"
             style={{ fontSize: "var(--fs-h3)" }}
           >
             {post.title}
             {/* terminal-prompt cursor — echoes the "field notes_" page
                 title; sits invisible (reserving its width so hover never
-                reflows the line) and fades in whisper-green on row hover. */}
+                reflows the line) and fades in whisper-green on row hover.
+                The title itself doesn't change on hover — the cursor and
+                the sliding `→` carry the affordance. */}
             <span
               aria-hidden
               className="text-whisper opacity-0 transition-opacity duration-300 ease-out group-hover:opacity-100"

--- a/components/ui/PostRow.tsx
+++ b/components/ui/PostRow.tsx
@@ -12,12 +12,18 @@ export const BLOG_GRID_COLS =
 
 // `2026-05-11` → `2026·05·11` — the field-log date style. The machine
 // value stays in <time dateTime>; only the display string gets the dots.
-const dotted = (iso: string) => iso.replaceAll("-", "·");
+// Shared with the post page (app/blog/[slug]/page.tsx).
+export const dottedDate = (iso: string) => iso.replaceAll("-", "·");
+
+// `08 min` — zero-padded read estimate. Shared with the post page.
+export const readLabel = (min: number) => `${String(min).padStart(2, "0")} min`;
 
 // Lowercase meta (11px, tracked, tabular figures) — like `.meta` but
-// without its forced uppercase, since `02 · 08 min · 1,920 wds` read
-// lowercase. `.meta` is an unlayered rule we can't override per-call.
-const META = "text-[0.6875rem] leading-[1.2] font-medium tracking-[0.16em]";
+// without its forced uppercase, since `02 · 08 min` reads lowercase.
+// `.meta` is an unlayered rule we can't override per-call. Shared with
+// the post page.
+export const META =
+  "text-[0.6875rem] leading-[1.3] font-medium tracking-[0.16em]";
 
 export function PostRow({
   post,
@@ -28,7 +34,8 @@ export function PostRow({
   num: string;
   delay: number;
 }) {
-  const minutes = `${String(post.readMin).padStart(2, "0")} min`;
+  const minutes = readLabel(post.readMin);
+  const date = dottedDate(post.date);
   const tags = post.tags ?? [];
 
   return (
@@ -43,7 +50,7 @@ export function PostRow({
         >
           <span>
             {num} <span aria-hidden>·</span>{" "}
-            <time dateTime={post.date}>{dotted(post.date)}</time>
+            <time dateTime={post.date}>{date}</time>
           </span>
           <span>{minutes}</span>
         </div>
@@ -60,7 +67,7 @@ export function PostRow({
           dateTime={post.date}
           className={`${META} hidden self-start tabular-nums opacity-55 @xl:mt-1.5 @xl:block`}
         >
-          {dotted(post.date)}
+          {date}
         </time>
 
         {/* title · summary · tags */}

--- a/content/blog/00-what-were-building.mdx
+++ b/content/blog/00-what-were-building.mdx
@@ -4,6 +4,7 @@ slug: what-were-building
 date: 2026-05-04
 summary: "What deCDN is, who it's for, and what the protocol composes — a plain-English introduction."
 bucket: pillar
+tags: [primer, protocol, architecture, overview]
 ---
 
 **decdn** is a content delivery network where there's no central operator. Bytes flow from anyone willing to serve them to anyone willing to pay for them, denominated in dollars, with cryptographic verification at the edge and no contract longer than a single megabyte. This post is the plain-English introduction.

--- a/content/blog/01-why-now.mdx
+++ b/content/blog/01-why-now.mdx
@@ -4,6 +4,7 @@ slug: why-now
 date: 2026-05-11
 summary: "Decentralized CDN attempts have been blocked for a decade by missing prerequisites — transport, addressing, settlement, L2s. All four finally landed."
 bucket: pillar
+tags: [prerequisites, transport, settlement, timing]
 ---
 
 Decentralized CDNs have been attempted for a decade. Most got stuck before they shipped. The thing that's different now isn't ambition — it's that the four prerequisite layers all became production-grade in the last 24–36 months. Until they did, every serious attempt was structurally blocked by problems outside its own protocol: the transport wasn't fast enough, the settlement layer was too expensive, the unit of account was too volatile, or the legal posture made compliance a single point of failure.

--- a/content/blog/02-decentralized-cdn-graveyard.mdx
+++ b/content/blog/02-decentralized-cdn-graveyard.mdx
@@ -4,6 +4,7 @@ slug: decentralized-cdn-graveyard
 date: 2026-05-11
 summary: "Six decade-spanning attempts at a decentralized CDN. What each got stuck on, and why those blockers are now resolved."
 bucket: pillar
+tags: [history, graveyard, post-mortems]
 ---
 
 The decentralized-CDN graveyard is real. Reading it carefully tells you exactly what to do differently. Six attempts span almost twenty years of work, dozens of token sales, and a combined raise well into the billions. None of them produced a network that competes with Cloudflare on price and latency for general-purpose delivery. Each one got stuck on something specific.

--- a/lib/blog.test.ts
+++ b/lib/blog.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getPost, parseSlug } from "./blog";
+import { countWords, getPost, listPosts, parseSlug } from "./blog";
 
 describe("parseSlug", () => {
   it.each(["a", "a-b", "a-b-c", "abc123", "a1-b2"])("accepts %j", (input) => {
@@ -31,4 +31,41 @@ describe("getPost", () => {
       expect(getPost(input)).toBeNull();
     },
   );
+});
+
+describe("countWords", () => {
+  it("counts whitespace-delimited tokens", () => {
+    expect(countWords("one two three")).toBe(3);
+    expect(countWords("  leading\tand\ntrailing  ")).toBe(3);
+  });
+
+  it("is 0 for blank input", () => {
+    expect(countWords("")).toBe(0);
+    expect(countWords("   \n\t ")).toBe(0);
+  });
+});
+
+describe("listPosts metadata", () => {
+  const posts = listPosts();
+
+  it("derives a positive word count and reading time per post", () => {
+    expect(posts.length).toBeGreaterThan(0);
+    for (const p of posts) {
+      expect(p.words).toBeGreaterThan(0);
+      expect(p.readMin).toBeGreaterThanOrEqual(1);
+      expect(p.readMin).toBe(Math.max(1, Math.round(p.words / 200)));
+    }
+  });
+
+  it("exposes tags as a non-empty string array when present", () => {
+    for (const p of posts) {
+      if (p.tags === undefined) continue;
+      expect(p.tags.length).toBeGreaterThan(0);
+      for (const t of p.tags) {
+        expect(typeof t).toBe("string");
+        expect(t).toBe(t.trim());
+        expect(t).not.toBe("");
+      }
+    }
+  });
 });

--- a/lib/blog.test.ts
+++ b/lib/blog.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it } from "vitest";
-import { countWords, getPost, listPosts, parseSlug } from "./blog";
+import {
+  countWords,
+  dottedDate,
+  getPost,
+  listPosts,
+  parseSlug,
+  parseTags,
+  readingMinutes,
+  readLabel,
+  seriesLabel,
+} from "./blog";
 
 describe("parseSlug", () => {
   it.each(["a", "a-b", "a-b-c", "abc123", "a1-b2"])("accepts %j", (input) => {
@@ -43,6 +53,65 @@ describe("countWords", () => {
     expect(countWords("")).toBe(0);
     expect(countWords("   \n\t ")).toBe(0);
   });
+
+  it("counts markdown punctuation as tokens (the documented over-estimate)", () => {
+    // `##` (ATX heading) and `[link](url)` are each one token.
+    expect(countWords("## Heading and a [link](url)")).toBe(5);
+  });
+});
+
+describe("readingMinutes", () => {
+  // 200 wpm with Math.round → the half-up boundary lands at 300 words.
+  it.each([
+    [0, 1],
+    [1, 1],
+    [100, 1],
+    [299, 1],
+    [300, 2],
+    [400, 2],
+    [500, 3],
+    [1000, 5],
+  ])("%d words → %d min", (words, min) => {
+    expect(readingMinutes(words)).toBe(min);
+  });
+});
+
+describe("display formatters", () => {
+  it("dottedDate swaps hyphens for middle dots", () => {
+    expect(dottedDate("2026-05-11")).toBe("2026·05·11");
+  });
+
+  it("readLabel zero-pads to two digits", () => {
+    expect(readLabel(8)).toBe("08 min");
+    expect(readLabel(12)).toBe("12 min");
+  });
+
+  it("seriesLabel zero-pads to two digits", () => {
+    expect(seriesLabel(2)).toBe("02");
+    expect(seriesLabel(11)).toBe("11");
+  });
+});
+
+describe("parseTags", () => {
+  it("returns undefined when absent or an empty array", () => {
+    expect(parseTags(undefined, "x.mdx")).toBeUndefined();
+    expect(parseTags([], "x.mdx")).toBeUndefined();
+  });
+
+  it("trims and de-duplicates, preserving source order", () => {
+    expect(
+      parseTags(["  transport ", "transport", "settlement"], "x.mdx"),
+    ).toEqual(["transport", "settlement"]);
+  });
+
+  it.each<[string, unknown]>([
+    ["a bare string", "primer"],
+    ["a non-string element", ["primer", 1]],
+    ["an empty-string element", ["primer", ""]],
+    ["a whitespace-only element", ["primer", "   "]],
+  ])("throws (with file context) on %s", (_label, input) => {
+    expect(() => parseTags(input, "bad.mdx")).toThrow(/bad\.mdx.*tags/s);
+  });
 });
 
 describe("listPosts metadata", () => {
@@ -67,5 +136,13 @@ describe("listPosts metadata", () => {
         expect(t).not.toBe("");
       }
     }
+  });
+
+  it("numbers the series 1..N (oldest = 1), newest first in the list", () => {
+    const numbers = posts.map((p) => p.seriesNumber).sort((a, b) => a - b);
+    expect(numbers).toEqual(
+      Array.from({ length: posts.length }, (_, i) => i + 1),
+    );
+    expect(posts[0]?.seriesNumber).toBe(posts.length);
   });
 });

--- a/lib/blog.ts
+++ b/lib/blog.ts
@@ -34,9 +34,22 @@ export type PostMeta = {
   date: IsoDate;
   summary: string;
   bucket?: string;
+  tags?: string[];
+  /** Whitespace-delimited token count of the raw MDX source. */
+  words: number;
+  /** Estimated reading time in whole minutes (>= 1), at ~200 wpm. */
+  readMin: number;
 };
 
 export type PostSource = PostMeta & { body: string };
+
+// Reading estimate from the raw MDX: markdown punctuation (`##`, `**`,
+// link syntax) counts toward the total, so this runs a touch high — the
+// same trade-off every "N min read" widget makes. Exported for tests.
+const WORDS_PER_MINUTE = 200;
+export const countWords = (s: string): number => (s.match(/\S+/g) ?? []).length;
+const readingMinutes = (words: number): number =>
+  Math.max(1, Math.round(words / WORDS_PER_MINUTE));
 
 // YAML auto-coerces `YYYY-MM-DD` into a Date — coerce back so consumers
 // always get a stable `2026-05-11` string. Returns empty string on
@@ -117,7 +130,33 @@ const parseEntry = (filename: string): PostSource | null => {
   }
   const bucket = typeof data.bucket === "string" ? data.bucket : undefined;
 
-  return { slug, title, date, summary, bucket, body: content };
+  let tags: string[] | undefined;
+  if ("tags" in data) {
+    const raw: unknown = data.tags;
+    if (
+      !Array.isArray(raw) ||
+      !raw.every((t): t is string => typeof t === "string" && t.trim() !== "")
+    ) {
+      throw new Error(
+        `[blog] ${filename}: frontmatter \`tags\` must be an array of non-empty strings when present`,
+      );
+    }
+    tags = raw.map((t) => t.trim());
+  }
+
+  const words = countWords(content);
+
+  return {
+    slug,
+    title,
+    date,
+    summary,
+    bucket,
+    tags,
+    words,
+    readMin: readingMinutes(words),
+    body: content,
+  };
 };
 
 // Single-process build with immutable source files; cache lets every
@@ -158,6 +197,9 @@ const toMeta = (e: PostSource): PostMeta => ({
   date: e.date,
   summary: e.summary,
   bucket: e.bucket,
+  tags: e.tags,
+  words: e.words,
+  readMin: e.readMin,
 });
 
 export function listPosts(): PostMeta[] {

--- a/lib/blog.ts
+++ b/lib/blog.ts
@@ -35,6 +35,10 @@ export type PostMeta = {
   summary: string;
   bucket?: string;
   tags?: string[];
+  /** 1-based place in the series, oldest = 1. Assigned after the
+   *  newest-first sort (see `readEntries`) so the index `#` column and
+   *  the post page `§ NN` always agree. */
+  seriesNumber: number;
   /** Whitespace-delimited token count of the raw MDX source. */
   words: number;
   /** Estimated reading time in whole minutes (>= 1), at ~200 wpm. */
@@ -48,8 +52,22 @@ export type PostSource = PostMeta & { body: string };
 // same trade-off every "N min read" widget makes. Exported for tests.
 const WORDS_PER_MINUTE = 200;
 export const countWords = (s: string): number => (s.match(/\S+/g) ?? []).length;
-const readingMinutes = (words: number): number =>
+export const readingMinutes = (words: number): number =>
   Math.max(1, Math.round(words / WORDS_PER_MINUTE));
+
+// --- display formatters (shared by the index list and the post page) ---
+
+// `2026-05-11` → `2026·05·11`. The machine-readable value stays in
+// `<time dateTime>`; only the rendered string gets the middle dots.
+export const dottedDate = (iso: string): string => iso.replaceAll("-", "·");
+
+const pad2 = (n: number): string => String(n).padStart(2, "0");
+
+/** `8` → `08 min`. Receives `PostMeta.readMin` (integer ≥ 1). */
+export const readLabel = (min: number): string => `${pad2(min)} min`;
+
+/** `2` → `02`. Receives `PostMeta.seriesNumber`. */
+export const seriesLabel = (n: number): string => pad2(n);
 
 // YAML auto-coerces `YYYY-MM-DD` into a Date — coerce back so consumers
 // always get a stable `2026-05-11` string. Returns empty string on
@@ -65,7 +83,32 @@ const formatDate = (value: unknown): string => {
 const fileToSlug = (filename: string): string =>
   filename.replace(/^\d+-/, "").replace(/\.mdx?$/, "");
 
-const parseEntry = (filename: string): PostSource | null => {
+// Frontmatter `tags`: optional array of non-empty strings. Returned
+// trimmed and de-duplicated in source order; an empty `[]` is treated as
+// "no tags" — same as omitting the key. Throws (with file context) on
+// any other shape. Exported for tests.
+export const parseTags = (
+  value: unknown,
+  filename: string,
+): string[] | undefined => {
+  if (value === undefined) return undefined;
+  if (
+    !Array.isArray(value) ||
+    !value.every((t): t is string => typeof t === "string" && t.trim() !== "")
+  ) {
+    throw new Error(
+      `[blog] ${filename}: frontmatter \`tags\` must be an array of non-empty strings when present`,
+    );
+  }
+  const tags = [...new Set(value.map((t) => t.trim()))];
+  return tags.length > 0 ? tags : undefined;
+};
+
+// Everything `parseEntry` can produce on its own — `seriesNumber` depends
+// on the post's position in the sorted list and is filled in by `readEntries`.
+type RawPost = Omit<PostSource, "seriesNumber">;
+
+const parseEntry = (filename: string): RawPost | null => {
   const raw = fs.readFileSync(path.join(POSTS_DIR, filename), "utf8");
   let parsed;
   try {
@@ -129,22 +172,7 @@ const parseEntry = (filename: string): PostSource | null => {
     );
   }
   const bucket = typeof data.bucket === "string" ? data.bucket : undefined;
-
-  let tags: string[] | undefined;
-  if ("tags" in data) {
-    const raw: unknown = data.tags;
-    if (
-      !Array.isArray(raw) ||
-      !raw.every((t): t is string => typeof t === "string" && t.trim() !== "")
-    ) {
-      throw new Error(
-        `[blog] ${filename}: frontmatter \`tags\` must be an array of non-empty strings when present`,
-      );
-    }
-    // An empty `tags: []` is treated as "no tags" — same as omitting the key.
-    tags = raw.length > 0 ? raw.map((t) => t.trim()) : undefined;
-  }
-
+  const tags = parseTags(data.tags, filename);
   const words = countWords(content);
 
   return {
@@ -181,14 +209,18 @@ const readEntries = (): PostSource[] => {
     .readdirSync(POSTS_DIR)
     .filter((f) => /\.mdx?$/.test(f))
     .map(parseEntry)
-    .filter((e): e is PostSource => e !== null)
+    .filter((e): e is RawPost => e !== null)
     .sort((a, b) => {
       // Newest first; tie-break on slug because readdir order isn't
       // portable across filesystems and stable sort would otherwise
       // flip same-date post order between machines.
       if (a.date !== b.date) return b.date.localeCompare(a.date);
       return a.slug.localeCompare(b.slug);
-    });
+    })
+    // Number the series after the sort: newest gets the highest number,
+    // oldest gets 1. Both the index `#` column and the post page `§ NN`
+    // read this, so they can't disagree.
+    .map((e, i, arr): PostSource => ({ ...e, seriesNumber: arr.length - i }));
   return cache;
 };
 
@@ -199,6 +231,7 @@ const toMeta = (e: PostSource): PostMeta => ({
   summary: e.summary,
   bucket: e.bucket,
   tags: e.tags,
+  seriesNumber: e.seriesNumber,
   words: e.words,
   readMin: e.readMin,
 });

--- a/lib/blog.ts
+++ b/lib/blog.ts
@@ -141,7 +141,8 @@ const parseEntry = (filename: string): PostSource | null => {
         `[blog] ${filename}: frontmatter \`tags\` must be an array of non-empty strings when present`,
       );
     }
-    tags = raw.map((t) => t.trim());
+    // An empty `tags: []` is treated as "no tags" — same as omitting the key.
+    tags = raw.length > 0 ? raw.map((t) => t.trim()) : undefined;
   }
 
   const words = countWords(content);


### PR DESCRIPTION
Closes #98 — the index and post-page scope of the blog redesign.

## What changed

**Data model — `lib/blog.ts`**
- `PostMeta` gains `tags?: string[]`, `seriesNumber: number` (1-based, oldest = 1; assigned once after the newest-first sort so the index `#` column and the post `§ NN` can't disagree), and computed `words` / `readMin` (≈200 wpm; runs slightly high since it counts raw MDX). `toMeta` projects all of them.
- `parseTags(value, filename)` is an exported pure validator: array of non-empty strings → trimmed + de-duplicated in source order; an empty `[]` → `undefined`; anything else throws with file context. `countWords` and `readingMinutes` are exported too; `parseEntry` returns `Omit<PostSource, "seriesNumber">` and `readEntries` fills `seriesNumber` in after the sort.
- Pure display formatters live here (used by both the index list and the post page): `dottedDate` (`2026-05-11` → `2026·05·11`), `readLabel` (`8` → `08 min`), `seriesLabel` (`2` → `02`).
- `content/blog/*.mdx`: `tags:` backfilled on the three posts.
- `lib/blog.test.ts`: 45 tests — `parseTags` (trim/dedupe/`[]`→undefined/throw cases incl. filename in the message), `readingMinutes` rounding boundary, the formatters, a `countWords` markdown-token case, and the `seriesNumber` 1..N invariant over the real corpus.

**Index — `app/blog/page.tsx` + new `components/ui/PostRow.tsx`, `components/ui/Pill.tsx`**
- A "field-log" table: a `#` / `DATE` / `TITLE · SUMMARY` / `READ` column header in `.meta` small-caps over a 2px `rule-2`, then one `PostRow` per post on a shared 5-track grid (`#` · date · title/summary · read · arrow — `BLOG_GRID_COLS`, also used by the header row so labels line up), faint `divide-current/12` between rows, staggered `data-reveal` entrance.
- The page heading is `field notes_` (whisper-green underscore, terminal-prompt style; no separate meta label), inside a `.rise` cascade with the lead.
- Each row: zero-padded `#` (from `seriesNumber`), `2026·05·11` dotted date (`<time>` keeps the ISO value), `font-bold` title, summary, `#tag` pills, a right-aligned `NN min` read estimate, and a `→` that slides + greens on hover. Hovering a row fades in a whisper-green `_` cursor after the title and slides that `→` — the title itself holds steady (no colour shift); the layout collapses to a stack below `@xl`. `Pill` is an inert `<span>` (no nested anchors inside the row `<Link>`).
- `META` — the lowercase-meta class string — bakes in `tabular-nums`; shared with the post page.

**Post page — `app/blog/[slug]/page.tsx`**
- "← field notes" back link (`aria-label="Back to field notes"`); meta strip `§ NN · 2026·05·11 · NN min`; `font-bold` H1; tag pills; `<Prose>` body untouched; prev/next ("← earlier" / "later →", glyphs `aria-hidden`) derived from `seriesNumber` ± 1 (omitted at the ends) — on hover the `←`/`→` glyph slides + greens and the `earlier`/`later` label lifts; the title stays put, same restraint as the index row.
- `tags` flow into OpenGraph `article:tag`; the `BlogPosting` JSON-LD gains `keywords` + `wordCount`. The OG *image* is still the site card.

**`app/layout.tsx`**: no font-weight change in the final state — Geist loads 400–700; titles are `font-bold`.

**Navigation — `components/site/ScrollReveal.tsx`, `components/site/Chrome.tsx`**
- `ScrollReveal` and `Chrome`'s `IntersectionObserver`s ran in `useEffect(…, [])` — once per SPA session, since both sit in the root layout (no `template.tsx`, so it never remounts). A `next/link` client-side nav swaps the page DOM without re-firing those effects, so the new route's `[data-reveal]` nodes were never observed and stayed at `opacity:0` on the JS-fallback path (Firefox, Safari < 26; modern browsers reveal via the CSS `animation-timeline: view()`) — the new `PostRow`s were invisible after clicking "Blog" in the navbar; a hard reload of `/blog/` worked. Same cause left the navbar's section-tone observer frozen → white-on-white nav on `/blog/` when arriving from a dark home section. (Latent on `main` too — it bit the home-page sections on any `<Link>` nav back to `/`; the shared-component fix covers that.)
- Both observers (plus the `scrolled` re-sync) are now keyed on `usePathname()`, so they re-bind to the new route's elements; effects run after the new DOM is committed, so the re-run query picks them up. Hash-only links (`/#compare`) leave `pathname` unchanged, so no needless rebuilds.

## Verification
- `pnpm test` — 45 pass · `pnpm lint` — clean · `pnpm format:check` — clean · `pnpm build` — static export emits `out/blog/index.html` + the three `out/blog/<slug>/index.html`; `dynamicParams = false` / `generateStaticParams` untouched; built JSON-LD includes `keywords` / `wordCount`; the index `#` column renders `01`/`02`/`03` and the post page `§ 02`.
- Navbar **Blog** link (client-side nav): the post list reveals — `document.querySelectorAll('[data-reveal][data-revealed="true"]')` is non-empty on `/blog/` reached that way (was empty before the fix); arriving from a dark home section, the nav reads dark-on-light, not white-on-white. `pnpm dev` — `/`, `/blog/`, `/blog/<slug>/` all 200, no console errors.
- Hover: index `<h2>` and the prev/next title spans render `class="hug … font-bold"` with no `group-hover:opacity-*`; the glyph spans carry `group-hover:-translate-x-1 group-hover:text-whisper` (and `translate-x-1` on the right card).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
