### PR TITLE
fix(blog): capitalize post headings, center body, tighten heading rhythm

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -127,9 +127,12 @@ export default async function BlogPost({
             <span aria-hidden>←</span> field notes
           </Link>
 
-          <header className="flex flex-col gap-6">
+          {/* Centered masthead — meta line, title, and tags align on the
+              page's vertical axis above the (centered) body. The "← field
+              notes" back-link above stays flush-left as nav chrome. */}
+          <header className="flex flex-col items-center gap-6 text-center">
             <div
-              className={`${META} flex flex-wrap items-center gap-x-3 gap-y-1 tabular-nums opacity-50`}
+              className={`${META} flex flex-wrap items-center justify-center gap-x-3 gap-y-1 tabular-nums opacity-50`}
             >
               <span>§ {num}</span>
               <span aria-hidden>·</span>
@@ -145,7 +148,7 @@ export default async function BlogPost({
               {post.title}
             </h1>
             {tags.length > 0 && (
-              <ul className="flex flex-wrap gap-2">
+              <ul className="flex flex-wrap justify-center gap-2">
                 {tags.map((tag) => (
                   <li key={tag}>
                     <Pill>#{tag}</Pill>

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -142,7 +142,7 @@ export default async function BlogPost({
             </div>
             <h1
               id="post-h"
-              className="hug leading-[0.95] font-bold"
+              className="hug text-balance leading-[0.95] font-bold"
               style={{ fontSize: "var(--fs-h2)" }}
             >
               {post.title}

--- a/app/globals.css
+++ b/app/globals.css
@@ -875,6 +875,13 @@ a.underline-brutal:hover .arrow {
   font-weight: 600;
   letter-spacing: -0.03em;
   line-height: 1.05;
+}
+
+/* Larger gap before an h2 than the base 1.4em — scoped to non-first
+   children so a post that opens on a heading doesn't get a stray top
+   margin (mirrors `.prose > * + *`; wins it on specificity). h3 needs no
+   such rule: its pre-heading gap is just the base 1.4em. */
+.prose > * + h2 {
   margin-block-start: 1.7em;
 }
 
@@ -883,7 +890,6 @@ a.underline-brutal:hover .arrow {
   font-weight: 600;
   letter-spacing: -0.01em;
   line-height: 1.2;
-  margin-block-start: 1.4em;
 }
 
 .prose p,

--- a/app/globals.css
+++ b/app/globals.css
@@ -858,6 +858,7 @@ a.underline-brutal:hover .arrow {
 
 .prose {
   max-width: 68ch;
+  margin-inline: auto; /* center the reading column within the wide Frame */
   color: var(--ink);
 }
 
@@ -874,7 +875,7 @@ a.underline-brutal:hover .arrow {
   font-weight: 600;
   letter-spacing: -0.03em;
   line-height: 1.05;
-  margin-block-start: 2.4em;
+  margin-block-start: 1.7em;
 }
 
 .prose h3 {
@@ -882,7 +883,7 @@ a.underline-brutal:hover .arrow {
   font-weight: 600;
   letter-spacing: -0.01em;
   line-height: 1.2;
-  margin-block-start: 2em;
+  margin-block-start: 1.4em;
 }
 
 .prose p,

--- a/content/blog/00-what-were-building.mdx
+++ b/content/blog/00-what-were-building.mdx
@@ -9,13 +9,13 @@ tags: [primer, protocol, architecture, overview]
 
 **decdn** is a content delivery network where there's no central operator. Bytes flow from anyone willing to serve them to anyone willing to pay for them, denominated in dollars, with cryptographic verification at the edge and no contract longer than a single megabyte. This post is the plain-English introduction.
 
-## the elevator version
+## The elevator version
 
 A traditional CDN is a company that runs servers near your users and charges your business a monthly bill. CloudFront, Fastly, Akamai, Cloudflare. They cache your content, route around the slow paths of the public internet, and absorb traffic spikes for you. They charge $0.04–$0.20 per gigabyte. Their operations are opaque to you, and you're locked in to whoever you signed with.
 
 decdn is the same job — caching content near users, routing around the slow paths, absorbing spikes — but the operators are anyone with a server and a stake. They compete on price and latency. There's no monthly bill. You pay per megabyte, in USDC, only for what you actually pulled. The target market rate is **$0.01/GB**, four to twenty times cheaper than incumbent list pricing.
 
-## the two roles
+## The two roles
 
 There are two kinds of participant in the network.
 
@@ -25,7 +25,7 @@ There are two kinds of participant in the network.
 
 There's no third role. No platform. No middleman. The protocol is the platform.
 
-## what's underneath
+## What's underneath
 
 Every part of the stack is a primitive that already exists. decdn is the protocol that composes them.
 
@@ -38,7 +38,7 @@ Every part of the stack is a primitive that already exists. decdn is the protoco
 
 The protocol surface is thin: a wire format for probe and delivery, a payment channel contract, a staking registry, a slashing judge, a content blacklist, and a governance system. We did not invent any of the underlying primitives. We invented the protocol that composes them.
 
-## the economic shape
+## The economic shape
 
 Two currencies, doing two jobs.
 
@@ -48,7 +48,7 @@ Two currencies, doing two jobs.
 
 The split is deliberate. Volatility goes in one currency, used for alignment over long horizons. Stability goes in the other, used for payments matched to fiat-denominated server bills.
 
-## what we're not
+## What we're not
 
 To set expectations, here's what decdn does _not_ do.
 
@@ -57,7 +57,7 @@ To set expectations, here's what decdn does _not_ do.
 - **We don't pay operators in our own token.** Delivery is in USDC. Operator P&L tracks fiat costs in fiat-pegged revenue.
 - **We don't bolt onto an existing CDN.** This is its own protocol from the bottom up — not a sidecar, not a plugin layer, not an "edge computing" wrapper around someone else's bandwidth.
 
-## who this is for
+## Who this is for
 
 If you're a **node operator** — a sysadmin, a homelabber, a datacenter shop with spare bandwidth — decdn is supply-side opportunity. Stake, register, serve, earn USDC.
 

--- a/content/blog/01-why-now.mdx
+++ b/content/blog/01-why-now.mdx
@@ -31,7 +31,7 @@ Earlier networks (BitTorrent, IPFS, Filecoin retrieval) used SHA-256 or SHA-1 pi
 
 Result: every byte we deliver is verified by the receiving client at line rate. We do not need a separate proof-of-delivery oracle. The retrieval problem Filecoin had to design a whole sub-protocol around — proving you delivered the right bytes — is just not a problem we have to solve.
 
-## Settlement: stablecoins are now load-bearing financial infrastructure
+## Settlement: Stablecoins are now load-bearing financial infrastructure
 
 USDC and USDT cleared north of $10T of on-chain volume in 2024 and are settled by Circle / Tether against actual reserves with monthly attestations. They are no longer "crypto experiments" — they are how dollars move on public chains. For a network of node operators with real infrastructure costs (VPS, bandwidth, storage), this is the difference between a viable business and a casino.
 
@@ -39,7 +39,7 @@ A node operator who books $300/month in earnings keeps $300/month of buying powe
 
 Five years ago the only way to pay node operators on-chain was a volatile native token. Every prior decentralized delivery network priced bandwidth in something whose value could halve overnight. We don't.
 
-## L2s: payment channels are finally cheap enough to bother with
+## L2s: Payment channels are finally cheap enough to bother with
 
 Per-MB delivery payments are on the order of $0.00001 — six orders of magnitude below any L1 transaction fee. Without an off-chain channel mechanism the economics never close. But payment channels need to _open_ and _settle_ on-chain, which on Ethereum mainnet costs $5–50 per transaction. That kills the channel before it starts.
 

--- a/content/blog/01-why-now.mdx
+++ b/content/blog/01-why-now.mdx
@@ -11,7 +11,7 @@ Decentralized CDNs have been attempted for a decade. Most got stuck before they 
 
 **decdn** is the first attempt that gets to design _only_ the protocol, because the rails it runs on are finally ready. This is what changed.
 
-## transport: QUIC stopped being a research project
+## Transport: QUIC stopped being a research project
 
 QUIC was an IETF draft until 2021. By 2024 it carried roughly a third of public web traffic and shipped natively in every major OS. The properties that matter for a delivery network are now load-bearing parts of the public internet, not a thing we have to build.
 
@@ -21,7 +21,7 @@ QUIC was an IETF draft until 2021. By 2024 it carried roughly a third of public 
 
 QUIC plus iroh isn't incremental. It's the difference between "CDN-grade transport requires CDN-grade infrastructure" and "CDN-grade transport runs on a $5 VPS."
 
-## addressing: BLAKE3 made verification free
+## Addressing: BLAKE3 made verification free
 
 Earlier networks (BitTorrent, IPFS, Filecoin retrieval) used SHA-256 or SHA-1 piece hashes. Verification was either expensive enough to skip on commodity hardware (SHA-256 at multi-gigabit) or insecure enough to need a separate proof oracle. BLAKE3 changed that.
 
@@ -31,7 +31,7 @@ Earlier networks (BitTorrent, IPFS, Filecoin retrieval) used SHA-256 or SHA-1 pi
 
 Result: every byte we deliver is verified by the receiving client at line rate. We do not need a separate proof-of-delivery oracle. The retrieval problem Filecoin had to design a whole sub-protocol around — proving you delivered the right bytes — is just not a problem we have to solve.
 
-## settlement: stablecoins are now load-bearing financial infrastructure
+## Settlement: stablecoins are now load-bearing financial infrastructure
 
 USDC and USDT cleared north of $10T of on-chain volume in 2024 and are settled by Circle / Tether against actual reserves with monthly attestations. They are no longer "crypto experiments" — they are how dollars move on public chains. For a network of node operators with real infrastructure costs (VPS, bandwidth, storage), this is the difference between a viable business and a casino.
 
@@ -51,7 +51,7 @@ The same maturity wave gave us:
 - **OpenZeppelin SignatureChecker** supporting both EOA and ERC-1271 smart-account signatures uniformly across all our contracts.
 - **Circle's CCTP** for native USDC bridging across L2s, removing the trust assumption of wrapped-token bridges.
 
-## demand caught up at the same time
+## Demand caught up at the same time
 
 The supply-side primitives matured in parallel with a demand shock that didn't exist in 2020. Payload sizes grew an order of magnitude — modern open-source ML weights run 10–700GB; high-bitrate media, container images, and dataset distributions all push hundreds of GB; package archives are a hundred-fold larger than they were a decade ago. Legacy CDN list pricing didn't move: Cloudflare R2, AWS CloudFront, and Akamai are still in the $0.04–$0.20/GB band, the same as ten years ago. The teams shipping these payloads cannot run that math.
 
@@ -59,7 +59,7 @@ Centralized risk got worse, not better. A handful of hosts carry the load for in
 
 The demand-side market existed at this scale for the first time around 2023. The supply-side primitives became viable around the same time. The intersection is the wedge.
 
-## the window
+## The window
 
 The supply-side primitives are ready. The demand-side pain is acute. The category has no incumbent. Three things have to be true at once for a decentralized delivery network to work, and for the first time, all three are.
 

--- a/content/blog/02-decentralized-cdn-graveyard.mdx
+++ b/content/blog/02-decentralized-cdn-graveyard.mdx
@@ -53,7 +53,7 @@ The longest-running cautionary tale: nineteen years from founding to phase-1 mai
 
 **The lesson:** scope discipline is a feature.
 
-## the common pattern
+## The common pattern
 
 Every prior attempt got stuck on at least one of these:
 


### PR DESCRIPTION
## What

Polish fixes to the long-form blog posts:

1. **Capitalized `##` section headings** in all three MDX posts — e.g. `the elevator version` → `The elevator version`, `transport: …` → `Transport: …`, `the common pattern` → `The common pattern`. The deliberate lowercase aesthetic belongs to the chrome (`field notes_` index title, `.meta` labels), not to in-body section titles. Acronym/proper-noun headings (`## IPFS …`, `## Filecoin …`, `## Theta …`, `## Livepeer …`, `## Arweave / Sia / Storj …`, `## MaidSafe / Safe Network …`) are left as-is. Frontmatter `title:` fields were already capitalized. Also capitalized the word after the colon in `## Settlement: Stablecoins …` and `## L2s: Payment channels …` for internal consistency.
2. **Centered the MDX body column** — added `margin-inline: auto` to `.prose` so the 68ch reading column sits centered within the 1280px `Frame` instead of hugging the left edge. Body text stays left-aligned; the rule above the body and the prev/next nav stay full-width. On phone widths the auto margin collapses to zero, so nothing changes there.
3. **Centered the post masthead** — the meta line (`§ · date · read`), the post `<h1>` (e.g. "Why now"), and the tag pills now align on the page's vertical axis, sitting as a centered masthead above the centered body. The "← field notes" back-link stays flush-left as nav chrome. The `<h1>` gets `text-balance` so a two-line title breaks evenly.
4. **Tightened heading spacing** — the pre-heading gap before an `h2` is `1.7em` (was `2.4em`), scoped to `.prose > * + h2` so a post that opens on a heading doesn't get a stray top margin (mirrors the `.prose > * + *` lobotomized-owl rule). `.prose h3`'s explicit `margin-block-start` (was `2em`) is dropped — the base `.prose > * + *` already supplies `1.4em`.

## Files

- `content/blog/00-what-were-building.mdx`, `content/blog/01-why-now.mdx`, `content/blog/02-decentralized-cdn-graveyard.mdx` — heading capitalization only
- `app/globals.css` — `.prose` (`margin-inline: auto`), `.prose h2` → `.prose > * + h2` for the pre-heading margin, `.prose h3` (dropped redundant `margin-block-start`)
- `app/blog/[slug]/page.tsx` — centered post header (`items-center` / `text-center` / `justify-center`), `text-balance` on the `<h1>`

No data-layer changes; `lib/blog.ts` passes `body` through verbatim, and no anchor/TOC/slug machinery consumes the heading text.

## Review

Addressed the Gemini Code Assist review (heading-margin scoping, `Stablecoins` capitalization) and a follow-up multi-agent review (`text-balance` on the centered title). Code-reviewer + comment-analyzer found no critical/important issues.

## Verification

- `pnpm lint` ✓
- `pnpm format:check` ✓
- `pnpm test` — 45 passing ✓
- `pnpm build` — static export clean; built HTML has `<h2>The elevator version</h2>` / `<h2>Settlement: Stablecoins are now load-bearing financial infrastructure</h2>` / `<h1 … class="hug text-balance …">`, built CSS has `.prose{…;margin-inline:auto}` and `.prose>*+h2{margin-block-start:1.7em}` with no `margin-block-start` on `.prose h3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)