### PR TITLE
chore(theme): drop unused --text-display token

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -46,7 +46,6 @@
   --text-h2: clamp(1.875rem, 5.8vw, 5.25rem);
   --text-method-row: clamp(2rem, 6.5vw, 6rem);
   --text-h1: clamp(2.25rem, 7vw, 6.5rem);
-  --text-display: clamp(3.5rem, 14vw, 12.5rem);
   --text-price: clamp(1.125rem, 5vw, 4rem);
 }
 


### PR DESCRIPTION
## What

Removes `--text-display: clamp(3.5rem, 14vw, 12.5rem)` from `app/globals.css`'s `@theme inline` block.

## Why

Nothing references it — `grep` for `text-display` / `--text-display` across `app/`, `components/`, `lib/`, `content/` finds only the declaration, and Tailwind v4 never emits a `text-display` utility because it's never used in a class. Dead since before #101 (it was `--fs-display` then; #101 renamed it along with the rest of the scale for namespace coherence).

The rest of the `@theme inline` block was audited at the same time — every other `--text-*` rung, the `--frame-*` tokens, the `--color-*` tokens, and `--nav-h` are all referenced. One borderline case, `--font-sans`, has no call site but overrides Tailwind's built-in `font-sans` utility — tracked in #105, not in scope here.

## Verification

- `grep -rn "text-display\|--text-display" app/ components/ lib/ content/` → no matches
- `pnpm lint` → clean
- `pnpm exec tsc --noEmit` → clean
- `pnpm build` → static export succeeded

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)