### PR TITLE
feat(blog): per-post OG image for JSON-LD and social cards (#88)

### DIFF
--- a/app/blog/[slug]/opengraph-image.tsx
+++ b/app/blog/[slug]/opengraph-image.tsx
@@ -71,12 +71,20 @@ export default async function Image({ params }: { params: Promise<Params> }) {
       </div>
 
       {/* Title — echoes the site `.hug` treatment (tight negative
-            tracking on large display sizes). */}
+            tracking on large display sizes). The `maxHeight` /
+            `overflow` combo is a defensive cap so a pathologically long
+            title can't push the bottom row off the 630px canvas:
+            630 − 160 (top/bottom padding) − ~52 (eyebrow + bottom row at
+            22px) ≈ 418px available, rounded down to a safe 400. The
+            44-char auto-shrink heuristic above keeps current titles
+            well inside this bound. */}
       <div
         style={{
           fontSize: titleSize,
           letterSpacing: "-0.03em",
           lineHeight: 1.05,
+          maxHeight: 400,
+          overflow: "hidden",
         }}
       >
         {post.title}

--- a/app/blog/[slug]/opengraph-image.tsx
+++ b/app/blog/[slug]/opengraph-image.tsx
@@ -1,0 +1,106 @@
+import { ImageResponse } from "next/og";
+import { notFound } from "next/navigation";
+import { dottedDate, getPost, listPosts, seriesLabel } from "@/lib/blog";
+
+// Static export: under `output: "export"` Next refuses to collect a
+// metadata Route Handler without this flag — same rule as
+// app/sitemap.xml/route.ts, app/sitemap-pages.xml/route.ts, app/robots.ts
+// (see AGENTS.md "Static export only").
+export const dynamic = "force-static";
+
+// The metadata route does NOT inherit generateStaticParams from the
+// sibling page.tsx — each file convention enumerates its own params.
+// Driving both off listPosts() keeps them single-sourced.
+export function generateStaticParams() {
+  return listPosts().map((p) => ({ slug: p.slug }));
+}
+
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+// Static alt by design. A per-post alt would force `generateImageMetadata`,
+// which inserts an `id` segment into the emitted URL — the card itself
+// carries the title visually, so a brand-level alt is acceptable.
+export const alt = "deCDN — field notes";
+
+// Inlined palette — Satori can't see app/globals.css CSS-var tokens.
+// Keep in sync with --ink / --paper / --whisper there (lines 3–6).
+const INK = "#000000";
+const PAPER = "#ffffff";
+const WHISPER = "#0f9d6a";
+
+type Params = { slug: string };
+
+export default async function Image({ params }: { params: Promise<Params> }) {
+  const { slug } = await params;
+  const post = getPost(slug);
+  if (!post) notFound();
+
+  // Auto-shrink long titles so two-line layouts stay inside the safe
+  // area. The cutoff (~44 chars) is the longest title that still fits
+  // on one line at 76px in Geist Regular at this canvas width.
+  const titleSize = post.title.length > 44 ? 60 : 76;
+
+  return new ImageResponse(
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "space-between",
+        padding: 80,
+        backgroundColor: INK,
+        color: PAPER,
+      }}
+    >
+      {/* Eyebrow — echoes the site `.meta` treatment (uppercase, wide
+            tracking, dimmed). */}
+      <div
+        style={{
+          fontSize: 22,
+          letterSpacing: "0.22em",
+          color: "rgba(255, 255, 255, 0.6)",
+        }}
+      >
+        DECDN · FIELD LOG
+      </div>
+
+      {/* Title — echoes the site `.hug` treatment (tight negative
+            tracking on large display sizes). */}
+      <div
+        style={{
+          fontSize: titleSize,
+          letterSpacing: "-0.03em",
+          lineHeight: 1.05,
+        }}
+      >
+        {post.title}
+      </div>
+
+      {/* Bottom row — date · series · whisper dot. `space-between`
+            pins the dot to the right edge without absolute positioning. */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          fontSize: 22,
+          letterSpacing: "0.22em",
+          color: "rgba(255, 255, 255, 0.6)",
+        }}
+      >
+        <span>{dottedDate(post.date)}</span>
+        <span>§ {seriesLabel(post.seriesNumber)}</span>
+        <span
+          style={{
+            width: 12,
+            height: 12,
+            borderRadius: 6,
+            backgroundColor: WHISPER,
+          }}
+        />
+      </div>
+    </div>,
+    { ...size },
+  );
+}

--- a/app/blog/[slug]/opengraph-image.tsx
+++ b/app/blog/[slug]/opengraph-image.tsx
@@ -67,7 +67,7 @@ export default async function Image({ params }: { params: Promise<Params> }) {
           color: "rgba(255, 255, 255, 0.6)",
         }}
       >
-        DECDN · FIELD LOG
+        DECDN · FIELD NOTES
       </div>
 
       {/* Title — echoes the site `.hug` treatment (tight negative

--- a/app/blog/[slug]/opengraph-image.tsx
+++ b/app/blog/[slug]/opengraph-image.tsx
@@ -1,6 +1,11 @@
 import { ImageResponse } from "next/og";
-import { notFound } from "next/navigation";
-import { dottedDate, getPost, listPosts, seriesLabel } from "@/lib/blog";
+import {
+  dottedDate,
+  getPost,
+  listPosts,
+  ogCardSlugs,
+  seriesLabel,
+} from "@/lib/blog";
 
 // Static export: under `output: "export"` Next refuses to collect a
 // metadata Route Handler without this flag — same rule as
@@ -10,14 +15,13 @@ export const dynamic = "force-static";
 
 // The metadata route does NOT inherit generateStaticParams from the
 // sibling page.tsx — each file convention enumerates its own params.
-// Driving both off listPosts() keeps them single-sourced. Posts with a
-// frontmatter `image:` override are filtered out: their <meta> tags
-// point at the override URL, so the generated card would ship as an
-// unreferenced PNG in the static export.
+// Driving both off listPosts() keeps them single-sourced. The
+// `ogCardSlugs` filter (see lib/blog.ts) drops posts that override the
+// OG image via frontmatter — without it the static export would ship a
+// card PNG that no <meta> tag references, wasting build cycles and
+// leaving an unreachable artifact in `out/`.
 export function generateStaticParams() {
-  return listPosts()
-    .filter((p) => !p.image)
-    .map((p) => ({ slug: p.slug }));
+  return ogCardSlugs(listPosts());
 }
 
 export const size = { width: 1200, height: 630 };
@@ -28,7 +32,7 @@ export const contentType = "image/png";
 export const alt = "deCDN — field notes";
 
 // Inlined palette — Satori can't see app/globals.css CSS-var tokens.
-// Keep in sync with --ink / --paper / --whisper there (lines 3–6).
+// Keep in sync with --ink / --paper / --whisper in app/globals.css.
 const INK = "#000000";
 const PAPER = "#ffffff";
 const WHISPER = "#0f9d6a";
@@ -38,7 +42,16 @@ type Params = { slug: string };
 export default async function Image({ params }: { params: Promise<Params> }) {
   const { slug } = await params;
   const post = getPost(slug);
-  if (!post) notFound();
+  if (!post) {
+    // Closed-world under `output: "export"`: the only way we get here is
+    // if generateStaticParams() and getPost() disagree (e.g. listPosts
+    // returned a slug parseSlug now rejects). Surface it as a loud build
+    // error rather than `notFound()`, which has no runtime under static
+    // export and would silently emit a missing/empty PNG.
+    throw new Error(
+      `[blog/opengraph-image] no post for slug "${slug}" — generateStaticParams() and getPost() are out of sync`,
+    );
+  }
 
   // Auto-shrink long titles so two-line layouts stay inside the safe
   // area. The cutoff (~44 chars) is the longest title that still fits

--- a/app/blog/[slug]/opengraph-image.tsx
+++ b/app/blog/[slug]/opengraph-image.tsx
@@ -10,9 +10,14 @@ export const dynamic = "force-static";
 
 // The metadata route does NOT inherit generateStaticParams from the
 // sibling page.tsx — each file convention enumerates its own params.
-// Driving both off listPosts() keeps them single-sourced.
+// Driving both off listPosts() keeps them single-sourced. Posts with a
+// frontmatter `image:` override are filtered out: their <meta> tags
+// point at the override URL, so the generated card would ship as an
+// unreferenced PNG in the static export.
 export function generateStaticParams() {
-  return listPosts().map((p) => ({ slug: p.slug }));
+  return listPosts()
+    .filter((p) => !p.image)
+    .map((p) => ({ slug: p.slug }));
 }
 
 export const size = { width: 1200, height: 630 };

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,4 +1,4 @@
-import type { Metadata, ResolvingMetadata } from "next";
+import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { MDXRemote } from "next-mdx-remote/rsc";
@@ -29,17 +29,17 @@ export function generateStaticParams() {
 
 type Params = { slug: string };
 
-export async function generateMetadata(
-  { params }: { params: Promise<Params> },
-  parent: ResolvingMetadata,
-): Promise<Metadata> {
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<Params>;
+}): Promise<Metadata> {
   const { slug } = await params;
   const post = getPost(slug);
   if (!post) notFound();
-  // Inherit the root file-convention og image so post shares get the
-  // site card instead of a blank one; see app/blog/page.tsx for the
-  // pattern and the reason we reuse ogImages for twitter.
-  const ogImages = (await parent).openGraph?.images ?? [];
+  // OG/Twitter images come from the sibling `opengraph-image.tsx` file
+  // convention — one per-post card, with the og→twitter fallback
+  // populating `twitter:image` automatically.
   return {
     title: post.title,
     description: post.summary,
@@ -51,13 +51,11 @@ export async function generateMetadata(
       type: "article",
       publishedTime: post.date,
       tags: post.tags,
-      images: ogImages,
     },
     twitter: {
       card: "summary_large_image",
       title: post.title,
       description: post.summary,
-      images: ogImages,
     },
   };
 }
@@ -91,7 +89,9 @@ export default async function BlogPost({
     datePublished: post.date,
     url: postUrl,
     mainEntityOfPage: postUrl,
-    image: `${SITE_URL}opengraph-image.png`,
+    // Extensionless to match the URL Next emits for the file-convention
+    // OG image (`out/blog/<slug>/opengraph-image`, no `.png`).
+    image: `${postUrl}opengraph-image`,
     keywords: post.tags?.join(", "),
     wordCount: post.words,
     author: { "@id": ORG_ID },

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -38,8 +38,14 @@ export async function generateMetadata({
   const post = getPost(slug);
   if (!post) notFound();
   // OG/Twitter images come from the sibling `opengraph-image.tsx` file
-  // convention — one per-post card, with the og→twitter fallback
-  // populating `twitter:image` automatically.
+  // convention by default — one per-post generated card, with the
+  // og→twitter fallback populating `twitter:image` automatically.
+  // Frontmatter `image:` (validated in lib/blog.ts) overrides both when
+  // present; the alt mirrors the post title because the override image
+  // doesn't carry the title visually the way the generated card does.
+  const ogImages = post.image
+    ? [{ url: post.image, alt: post.title }]
+    : undefined;
   return {
     title: post.title,
     description: post.summary,
@@ -51,11 +57,13 @@ export async function generateMetadata({
       type: "article",
       publishedTime: post.date,
       tags: post.tags,
+      ...(ogImages && { images: ogImages }),
     },
     twitter: {
       card: "summary_large_image",
       title: post.title,
       description: post.summary,
+      ...(ogImages && { images: ogImages }),
     },
   };
 }
@@ -89,9 +97,10 @@ export default async function BlogPost({
     datePublished: post.date,
     url: postUrl,
     mainEntityOfPage: postUrl,
-    // Extensionless to match the URL Next emits for the file-convention
-    // OG image (`out/blog/<slug>/opengraph-image`, no `.png`).
-    image: `${postUrl}opengraph-image`,
+    // Frontmatter `image:` wins when set; otherwise point at the
+    // file-convention OG card. Extensionless to match the URL Next emits
+    // (`out/blog/<slug>/opengraph-image`, no `.png`).
+    image: post.image ?? `${postUrl}opengraph-image`,
     keywords: post.tags?.join(", "),
     wordCount: post.words,
     author: { "@id": ORG_ID },

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -8,9 +8,11 @@ import { Pill } from "@/components/ui/Pill";
 import { META } from "@/components/ui/PostRow";
 import { Prose } from "@/components/ui/Prose";
 import {
+  buildOgImages,
   dottedDate,
   getPost,
   listPosts,
+  postImageUrl,
   readLabel,
   seriesLabel,
 } from "@/lib/blog";
@@ -38,14 +40,12 @@ export async function generateMetadata({
   const post = getPost(slug);
   if (!post) notFound();
   // OG/Twitter images come from the sibling `opengraph-image.tsx` file
-  // convention by default — one per-post generated card, with the
-  // og→twitter fallback populating `twitter:image` automatically.
-  // Frontmatter `image:` (validated in lib/blog.ts) overrides both when
-  // present; the alt mirrors the post title because the override image
-  // doesn't carry the title visually the way the generated card does.
-  const ogImages = post.image
-    ? [{ url: post.image, alt: post.title }]
-    : undefined;
+  // convention by default — Next's static-metadata merge step (see
+  // resolve-metadata.js in next/dist) populates both `og:image` and
+  // `twitter:image` with the same cache-busted URL automatically.
+  // Frontmatter `image:` overrides both when present; the override shape
+  // and the alt-as-title decision live in `buildOgImages` (lib/blog.ts).
+  const ogImages = buildOgImages(post);
   return {
     title: post.title,
     description: post.summary,
@@ -97,10 +97,11 @@ export default async function BlogPost({
     datePublished: post.date,
     url: postUrl,
     mainEntityOfPage: postUrl,
-    // Frontmatter `image:` wins when set; otherwise point at the
-    // file-convention OG card. Extensionless to match the URL Next emits
-    // (`out/blog/<slug>/opengraph-image`, no `.png`).
-    image: post.image ?? `${postUrl}opengraph-image`,
+    // Override-vs-fallback selection lives in `postImageUrl`; see the
+    // JSDoc there for the cache-buster mismatch between this URL and
+    // the og:image meta (same file underneath; Cloudflare ignores the
+    // query string on static assets).
+    image: postImageUrl(post, postUrl),
     keywords: post.tags?.join(", "),
     wordCount: post.words,
     author: { "@id": ORG_ID },

--- a/lib/blog.test.ts
+++ b/lib/blog.test.ts
@@ -158,6 +158,8 @@ describe("parseImage", () => {
     ["a dot-prefixed relative path", "./foo.png"],
     ["a protocol-relative URL", "//example.test/foo.png"],
     ["a single slash", "/"],
+    ["a host-less http URL", "http://"],
+    ["a host-less https URL", "https://"],
     ["a data URL", "data:image/png;base64,AAA"],
     ["an ftp URL", "ftp://example.test/foo.png"],
     ["a mailto URL", "mailto:x@y.z"],

--- a/lib/blog.test.ts
+++ b/lib/blog.test.ts
@@ -4,12 +4,14 @@ import {
   dottedDate,
   getPost,
   listPosts,
+  parseImage,
   parseSlug,
   parseTags,
   readingMinutes,
   readLabel,
   seriesLabel,
 } from "./blog";
+import { SITE_URL } from "./links";
 
 describe("parseSlug", () => {
   it.each(["a", "a-b", "a-b-c", "abc123", "a1-b2"])("accepts %j", (input) => {
@@ -111,6 +113,56 @@ describe("parseTags", () => {
     ["a whitespace-only element", ["primer", "   "]],
   ])("throws (with file context) on %s", (_label, input) => {
     expect(() => parseTags(input, "bad.mdx")).toThrow(/bad\.mdx.*tags/s);
+  });
+});
+
+describe("parseImage", () => {
+  it("returns undefined when absent", () => {
+    expect(parseImage(undefined, "x.mdx")).toBeUndefined();
+  });
+
+  it.each<[string, string, string]>([
+    [
+      "site-relative path",
+      "/blog-cards/foo.png",
+      `${SITE_URL}blog-cards/foo.png`,
+    ],
+    ["nested site-relative path", "/a/b/c.png", `${SITE_URL}a/b/c.png`],
+    [
+      "absolute https URL",
+      "https://example.test/foo.png",
+      "https://example.test/foo.png",
+    ],
+    [
+      "absolute http URL",
+      "http://example.test/foo.png",
+      "http://example.test/foo.png",
+    ],
+    [
+      "surrounding whitespace",
+      "  https://example.test/foo.png  ",
+      "https://example.test/foo.png",
+    ],
+  ])("accepts %s", (_label, input, expected) => {
+    expect(parseImage(input, "x.mdx")).toBe(expected);
+  });
+
+  it.each<[string, unknown]>([
+    ["a number", 42],
+    ["null", null],
+    ["an array", ["/foo.png"]],
+    ["an object", {}],
+    ["an empty string", ""],
+    ["a whitespace-only string", "   "],
+    ["a bare relative path", "foo.png"],
+    ["a dot-prefixed relative path", "./foo.png"],
+    ["a protocol-relative URL", "//example.test/foo.png"],
+    ["a single slash", "/"],
+    ["a data URL", "data:image/png;base64,AAA"],
+    ["an ftp URL", "ftp://example.test/foo.png"],
+    ["a mailto URL", "mailto:x@y.z"],
+  ])("throws (with file context) on %s", (_label, input) => {
+    expect(() => parseImage(input, "bad.mdx")).toThrow(/bad\.mdx.*image/s);
   });
 });
 

--- a/lib/blog.test.ts
+++ b/lib/blog.test.ts
@@ -1,15 +1,20 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildOgImages,
   countWords,
   dottedDate,
   getPost,
   listPosts,
+  ogCardSlugs,
   parseImage,
   parseSlug,
   parseTags,
+  postImageUrl,
   readingMinutes,
   readLabel,
   seriesLabel,
+  type PostMeta,
+  type Slug,
 } from "./blog";
 import { SITE_URL } from "./links";
 
@@ -143,8 +148,44 @@ describe("parseImage", () => {
       "  https://example.test/foo.png  ",
       "https://example.test/foo.png",
     ],
+    // Pins the "verbatim, not canonicalized" contract: the validator
+    // accepts but does NOT lowercase the host / re-encode the path.
+    // A future refactor switching to `parsed.toString()` would fail
+    // this case, making the behaviour change explicit rather than silent.
+    [
+      "mixed-case scheme and host preserved",
+      "HTTPS://Example.Test/Foo.png",
+      "HTTPS://Example.Test/Foo.png",
+    ],
+    [
+      "query string + fragment + port preserved",
+      "https://example.test:8443/foo.png?v=2#frag",
+      "https://example.test:8443/foo.png?v=2#frag",
+    ],
   ])("accepts %s", (_label, input, expected) => {
     expect(parseImage(input, "x.mdx")).toBe(expected);
+  });
+
+  // Pins the invariant that every accepted output is itself a parseable
+  // absolute URL — catches a regression in the site-relative branch where
+  // `SITE_URL`'s trailing slash + the input's leading slash double up
+  // into `https://decdn.org//foo.png`, or worse, `https://decdn.orgfoo`.
+  it("returns a parseable absolute URL for every accepted shape", () => {
+    const inputs = [
+      "/blog-cards/foo.png",
+      "/a/b/c.png",
+      "https://example.test/foo.png",
+      "http://example.test/foo.png",
+    ];
+    for (const input of inputs) {
+      const out = parseImage(input, "x.mdx");
+      expect(out).toBeDefined();
+      const parsed = new URL(out!);
+      expect(parsed.hostname.length).toBeGreaterThan(0);
+      // No accidental `//` in the pathname (the double-slash regression
+      // the trailing-slash invariant used to risk).
+      expect(parsed.pathname.startsWith("//")).toBe(false);
+    }
   });
 
   it.each<[string, unknown]>([
@@ -160,11 +201,129 @@ describe("parseImage", () => {
     ["a single slash", "/"],
     ["a host-less http URL", "http://"],
     ["a host-less https URL", "https://"],
+    [
+      "a malformed absolute URL (space in authority)",
+      "https://exa mple.test/x",
+    ],
     ["a data URL", "data:image/png;base64,AAA"],
     ["an ftp URL", "ftp://example.test/foo.png"],
     ["a mailto URL", "mailto:x@y.z"],
   ])("throws (with file context) on %s", (_label, input) => {
     expect(() => parseImage(input, "bad.mdx")).toThrow(/bad\.mdx.*image/s);
+  });
+
+  // Per Important #1 from the PR-review pass: the URL parser's reason
+  // for rejection has to surface, not get swallowed into the generic
+  // "must be a site-relative path…" message. Lock the specific phrasing
+  // so a future refactor can't quietly regress to a generic error.
+  it.each([
+    ["host-less http", "http://"],
+    ["host-less https", "https://"],
+    ["space in authority", "https://exa mple.test/x"],
+  ])(
+    "surfaces the URL parser's reason for malformed absolute URLs (%s)",
+    (_label, input) => {
+      expect(() => parseImage(input, "bad.mdx")).toThrow(/is not a valid URL/);
+    },
+  );
+});
+
+describe("buildOgImages", () => {
+  // Minimal PostMeta shape — `as Slug` / `as IsoDate` casts are safe
+  // because we're not exercising the brand here, just the metadata
+  // builder's read of `image` and `title`.
+  const base: PostMeta = {
+    slug: "p" as Slug,
+    title: "Why Now",
+    date: "2026-05-04" as PostMeta["date"],
+    summary: "x",
+    seriesNumber: 1,
+    words: 100,
+    readMin: 1,
+  };
+
+  it("returns undefined when the post has no image override", () => {
+    expect(buildOgImages(base)).toBeUndefined();
+  });
+
+  it("returns a single image with title-as-alt when image is set", () => {
+    const out = buildOgImages({
+      ...base,
+      image: "https://decdn.org/blog-cards/why-now.png",
+    });
+    expect(out).toEqual([
+      {
+        url: "https://decdn.org/blog-cards/why-now.png",
+        alt: "Why Now",
+      },
+    ]);
+  });
+});
+
+describe("postImageUrl", () => {
+  const base: PostMeta = {
+    slug: "p" as Slug,
+    title: "Why Now",
+    date: "2026-05-04" as PostMeta["date"],
+    summary: "x",
+    seriesNumber: 1,
+    words: 100,
+    readMin: 1,
+  };
+
+  it("falls back to the extensionless file-convention URL when no override", () => {
+    expect(postImageUrl(base, "https://decdn.org/blog/why-now/")).toBe(
+      "https://decdn.org/blog/why-now/opengraph-image",
+    );
+  });
+
+  it("returns the override URL verbatim when image is set", () => {
+    expect(
+      postImageUrl(
+        { ...base, image: "https://cdn.example/x.png" },
+        "https://decdn.org/blog/why-now/",
+      ),
+    ).toBe("https://cdn.example/x.png");
+  });
+});
+
+describe("ogCardSlugs", () => {
+  const post = (slug: string, image?: string): PostMeta => ({
+    slug: slug as Slug,
+    title: slug,
+    date: "2026-05-04" as PostMeta["date"],
+    summary: "x",
+    seriesNumber: 1,
+    words: 100,
+    readMin: 1,
+    image,
+  });
+
+  it("returns all slugs when no post overrides", () => {
+    expect(ogCardSlugs([post("a"), post("b"), post("c")])).toEqual([
+      { slug: "a" },
+      { slug: "b" },
+      { slug: "c" },
+    ]);
+  });
+
+  it("filters out posts whose frontmatter sets image:", () => {
+    expect(
+      ogCardSlugs([
+        post("a"),
+        post("b", "https://cdn.example/b.png"),
+        post("c"),
+      ]),
+    ).toEqual([{ slug: "a" }, { slug: "c" }]);
+  });
+
+  it("returns an empty array when every post overrides", () => {
+    expect(
+      ogCardSlugs([
+        post("a", "https://cdn.example/a.png"),
+        post("b", "https://cdn.example/b.png"),
+      ]),
+    ).toEqual([]);
   });
 });
 
@@ -189,6 +348,21 @@ describe("listPosts metadata", () => {
         expect(t).toBe(t.trim());
         expect(t).not.toBe("");
       }
+    }
+  });
+
+  // Mirror the tags loop for `image`. No fixture currently uses the
+  // override, so today this is a no-op — but the first time an author
+  // adds `image:` to a real post, this guards the invariant that the
+  // emitted value is always an absolute, parseable URL with a hostname.
+  it("exposes image as an absolute parseable URL with a hostname when present", () => {
+    for (const p of posts) {
+      if (p.image === undefined) continue;
+      expect(typeof p.image).toBe("string");
+      expect(p.image).toBe(p.image.trim());
+      expect(p.image.length).toBeGreaterThan(0);
+      const parsed = new URL(p.image);
+      expect(parsed.hostname.length).toBeGreaterThan(0);
     }
   });
 

--- a/lib/blog.ts
+++ b/lib/blog.ts
@@ -113,11 +113,15 @@ export const parseTags = (
 };
 
 // Frontmatter `image`: optional override for the generated OG card.
-// Accepts a site-relative path (leading `/` plus at least one char, e.g.
-// `/blog-cards/foo.png`) — resolved against `SITE_URL` — or an absolute
-// http/https URL. Anything else (relative without `/`, protocol-relative
-// `//`, `data:`/`mailto:`/`ftp:` schemes, non-string) throws with file
-// context. Exported for tests.
+// Accepts a site-relative path (leading `/` followed by a non-`/` char,
+// e.g. `/blog-cards/foo.png`) — resolved against `SITE_URL` — or an
+// absolute http/https URL. Anything else (relative without `/`,
+// protocol-relative `//`, `data:`/`mailto:`/`ftp:` schemes, non-string)
+// throws with file context. Exported for tests.
+//
+// The non-`/` next-char constraint on the site-relative regex is what
+// rejects protocol-relative `//host/path` here rather than via a
+// separate guard.
 const ABSOLUTE_HTTP_URL_RE = /^https?:\/\//i;
 const SITE_RELATIVE_PATH_RE = /^\/[^/]/;
 
@@ -129,23 +133,37 @@ export const parseImage = (
   if (typeof value === "string") {
     const trimmed = value.trim();
     if (SITE_RELATIVE_PATH_RE.test(trimmed)) {
-      // SITE_URL already ends in `/`, so strip the leading slash from
-      // the path before concatenating to avoid `//`.
-      return `${SITE_URL}${trimmed.slice(1)}`;
+      // `new URL(rel, base)` handles the trailing-slash join correctly
+      // whether or not SITE_URL ends in `/`, so we don't depend on that
+      // invariant. The result is a fully resolved absolute URL.
+      return new URL(trimmed, SITE_URL).toString();
     }
     if (ABSOLUTE_HTTP_URL_RE.test(trimmed)) {
-      // The regex gates "looks like an http(s) URL"; `new URL` then
-      // confirms the string actually parses AND the authority is
-      // non-empty. Catches host-less inputs (`http://`, `https://`)
-      // that the regex alone would let through and ship as broken
-      // og:image / JSON-LD values.
+      // The regex only screens for an http(s) scheme — `new URL` is the
+      // real validator. It throws on syntactically invalid inputs (e.g.
+      // `https://exa mple.com/foo`, `http://[::1`) and surfaces a parsed
+      // hostname we can check separately to catch host-less inputs like
+      // `http://` / `https://` that would otherwise parse-but-mean-
+      // nothing. Distinguish the two failure modes in the message so
+      // authors see the actual reason their URL was rejected.
+      let parsed: URL;
       try {
-        if (new URL(trimmed).hostname.length > 0) {
-          return trimmed;
-        }
-      } catch {
-        // Falls through to the shared throw below.
+        parsed = new URL(trimmed);
+      } catch (err) {
+        throw new Error(
+          `[blog] ${filename}: frontmatter \`image\` "${trimmed}" is not a valid URL — ${(err as Error).message}`,
+          { cause: err },
+        );
       }
+      if (parsed.hostname.length === 0) {
+        throw new Error(
+          `[blog] ${filename}: frontmatter \`image\` "${trimmed}" is missing a hostname`,
+        );
+      }
+      // Returned verbatim (not `parsed.toString()`) so authors keep
+      // control over the exact bytes that hit og:image / JSON-LD —
+      // case-sensitive paths, query-string order, etc.
+      return trimmed;
     }
   }
   throw new Error(
@@ -297,3 +315,32 @@ export function getPost(slug: string): PostSource | null {
   if (valid === null) return null;
   return readEntries().find((e) => e.slug === valid) ?? null;
 }
+
+// --- pure metadata builders (single-sourced so app/blog/[slug]/page.tsx
+// and app/blog/[slug]/opengraph-image.tsx share the same shape). Each
+// is a tiny function on plain data, deliberately decoupled from `next`,
+// React, and the route handlers so the contract is unit-testable here.
+
+/** OG / Twitter `images` array when the post has a frontmatter `image:`
+ *  override; `undefined` when absent so the file-convention card wins.
+ *  The override alt mirrors the post title because the override image
+ *  doesn't carry the title visually the way the generated card does. */
+export const buildOgImages = (
+  post: PostMeta,
+): { url: string; alt: string }[] | undefined =>
+  post.image ? [{ url: post.image, alt: post.title }] : undefined;
+
+/** BlogPosting JSON-LD `image` URL. Frontmatter override wins, otherwise
+ *  the extensionless file-convention card URL — extensionless because
+ *  that's how Next writes the route to `out/blog/<slug>/opengraph-image`
+ *  (no `.png`). The og:image meta gets a cache-busting `?<hash>` from
+ *  Next that JSON-LD doesn't have; Cloudflare ignores the query on
+ *  static assets so both resolve to the same file. */
+export const postImageUrl = (post: PostMeta, postUrl: string): string =>
+  post.image ?? `${postUrl}opengraph-image`;
+
+/** Slugs that should get a generated OG card — i.e., posts WITHOUT a
+ *  frontmatter `image:` override. Filtering here means the static export
+ *  doesn't emit a card PNG that no <meta> tag references. */
+export const ogCardSlugs = (posts: PostMeta[]): { slug: Slug }[] =>
+  posts.filter((p) => !p.image).map((p) => ({ slug: p.slug }));

--- a/lib/blog.ts
+++ b/lib/blog.ts
@@ -134,7 +134,18 @@ export const parseImage = (
       return `${SITE_URL}${trimmed.slice(1)}`;
     }
     if (ABSOLUTE_HTTP_URL_RE.test(trimmed)) {
-      return trimmed;
+      // The regex gates "looks like an http(s) URL"; `new URL` then
+      // confirms the string actually parses AND the authority is
+      // non-empty. Catches host-less inputs (`http://`, `https://`)
+      // that the regex alone would let through and ship as broken
+      // og:image / JSON-LD values.
+      try {
+        if (new URL(trimmed).hostname.length > 0) {
+          return trimmed;
+        }
+      } catch {
+        // Falls through to the shared throw below.
+      }
     }
   }
   throw new Error(

--- a/lib/blog.ts
+++ b/lib/blog.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import matter from "gray-matter";
+import { SITE_URL } from "./links";
 
 const POSTS_DIR = path.join(process.cwd(), "content", "blog");
 
@@ -35,6 +36,13 @@ export type PostMeta = {
   summary: string;
   bucket?: string;
   tags?: string[];
+  /** Optional per-post override for the OG/JSON-LD image. When set,
+   *  consumed as-is for `og:image`, `twitter:image`, and
+   *  `BlogPosting.image` — bypasses the generated
+   *  `app/blog/[slug]/opengraph-image.tsx` card. Site-relative paths
+   *  (leading `/`, e.g. `/blog-cards/foo.png`) are resolved against
+   *  `SITE_URL` at parse time. Validated by `parseImage`. */
+  image?: string;
   /** 1-based place in the series, oldest = 1. Assigned after the
    *  newest-first sort (see `readEntries`) so the index `#` column and
    *  the post page `§ NN` always agree. */
@@ -102,6 +110,36 @@ export const parseTags = (
   }
   const tags = [...new Set(value.map((t) => t.trim()))];
   return tags.length > 0 ? tags : undefined;
+};
+
+// Frontmatter `image`: optional override for the generated OG card.
+// Accepts a site-relative path (leading `/` plus at least one char, e.g.
+// `/blog-cards/foo.png`) — resolved against `SITE_URL` — or an absolute
+// http/https URL. Anything else (relative without `/`, protocol-relative
+// `//`, `data:`/`mailto:`/`ftp:` schemes, non-string) throws with file
+// context. Exported for tests.
+const ABSOLUTE_HTTP_URL_RE = /^https?:\/\//i;
+const SITE_RELATIVE_PATH_RE = /^\/[^/]/;
+
+export const parseImage = (
+  value: unknown,
+  filename: string,
+): string | undefined => {
+  if (value === undefined) return undefined;
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (SITE_RELATIVE_PATH_RE.test(trimmed)) {
+      // SITE_URL already ends in `/`, so strip the leading slash from
+      // the path before concatenating to avoid `//`.
+      return `${SITE_URL}${trimmed.slice(1)}`;
+    }
+    if (ABSOLUTE_HTTP_URL_RE.test(trimmed)) {
+      return trimmed;
+    }
+  }
+  throw new Error(
+    `[blog] ${filename}: frontmatter \`image\` must be a site-relative path (leading \`/\`) or an absolute http(s) URL when present`,
+  );
 };
 
 // Everything `parseEntry` can produce on its own — `seriesNumber` depends
@@ -173,6 +211,7 @@ const parseEntry = (filename: string): RawPost | null => {
   }
   const bucket = typeof data.bucket === "string" ? data.bucket : undefined;
   const tags = parseTags(data.tags, filename);
+  const image = parseImage(data.image, filename);
   const words = countWords(content);
 
   return {
@@ -182,6 +221,7 @@ const parseEntry = (filename: string): RawPost | null => {
     summary,
     bucket,
     tags,
+    image,
     words,
     readMin: readingMinutes(words),
     body: content,
@@ -231,6 +271,7 @@ const toMeta = (e: PostSource): PostMeta => ({
   summary: e.summary,
   bucket: e.bucket,
   tags: e.tags,
+  image: e.image,
   seriesNumber: e.seriesNumber,
   words: e.words,
   readMin: e.readMin,

--- a/public/_headers
+++ b/public/_headers
@@ -5,3 +5,11 @@
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=(), interest-cohort=()
   X-Frame-Options: DENY
+
+# Next emits the per-post OG image as an extensionless file
+# (out/blog/<slug>/opengraph-image, no .png). Cloudflare assigns
+# Content-Type by extension, and the global `X-Content-Type-Options:
+# nosniff` above would otherwise have social scrapers reject it as
+# application/octet-stream. Pin the type explicitly here.
+/blog/*/opengraph-image
+  Content-Type: image/png

--- a/public/_headers
+++ b/public/_headers
@@ -11,5 +11,11 @@
 # Content-Type by extension, and the global `X-Content-Type-Options:
 # nosniff` above would otherwise have social scrapers reject it as
 # application/octet-stream. Pin the type explicitly here.
+#
+# Forward-compat: this rule is tied to Next's *extensionless* emission.
+# If a future Next release writes `opengraph-image.png` instead, this
+# stanza becomes dead config (the extension would carry the type) — the
+# only visible signal would be the rule going unmatched in the Cloudflare
+# Pages headers preview. Revisit on a Next major bump.
 /blog/*/opengraph-image
   Content-Type: image/png


### PR DESCRIPTION
Closes #88

## What

Two-layer per-post OG / JSON-LD image strategy for blog posts:

1. **Default — generated card** (Next `opengraph-image.tsx` file convention). Every post gets a 1200×630 PNG built from its title, date, and series number using the site's ink / paper / whisper palette, with a `DECDN · FIELD NOTES` eyebrow matching the site's blog-section nomenclature. Drives `og:image`, `twitter:image`, and `BlogPosting.image`.
2. **Override — frontmatter `image:`**. Posts that ship with a real cover photo can set `image: /blog-cards/foo.png` (site-relative, resolved against `SITE_URL`) or `image: https://example.test/foo.png` (absolute http/https) in their MDX frontmatter. The override populates all three meta surfaces and short-circuits card generation for that slug.

## Why

Before this PR, `BlogPosting.image` and every post's `og:image` pointed at the site-wide OG card. `Article.image` in schema.org represents the article, not the publisher — so structured-data consumers (Google rich results, Slack / Discord / X unfurls) all advertised one identical image regardless of which post was shared.

## How

- **NEW** `app/blog/[slug]/opengraph-image.tsx` — per-slug `ImageResponse` rendering a 1200×630 PNG. Exports `dynamic = "force-static"` and its own `generateStaticParams` (both required under `output: "export"`; the metadata route doesn't inherit from the sibling `page.tsx`). Calls the pure `ogCardSlugs(listPosts())` helper to filter out posts with a frontmatter `image:` override so no unreferenced PNG ships into the static export. The title container caps at `maxHeight: 400` with `overflow: "hidden"` as a defensive guard against pathologically long titles pushing the bottom row off-canvas. If `generateStaticParams` and `getPost` ever disagree (shouldn't happen — closed-world contract under static export), the handler throws a slug-tagged build error rather than calling `notFound()`, which has no runtime under `output: "export"` and would silently emit a missing PNG.
- `lib/blog.ts`:
  - New `parseImage(value, filename)` validator. Accepts site-relative paths (resolved with `new URL(trimmed, SITE_URL)` — eliminates the `SITE_URL`-trailing-slash invariant) and absolute http / https URLs (kept verbatim so authors control the bytes that hit og:image). The absolute-URL branch validates with `new URL(...)` and distinguishes "not a valid URL — <parser reason>" from "missing a hostname", preserving `{ cause: err }` so the WHATWG parser's reason surfaces in build logs instead of being swallowed into a generic message. Rejects empty / whitespace strings, non-strings, relative-without-slash, protocol-relative, single slash, `data:`, `mailto:`, `ftp:`, and malformed authorities. Threaded as `image?: string` through `PostMeta`, `parseEntry`, and `toMeta`.
  - Three pure metadata builders (`buildOgImages`, `postImageUrl`, `ogCardSlugs`) — single-sourced from this module so `page.tsx` and `opengraph-image.tsx` share one shape and the contract is unit-testable without touching React or Next runtime imports.
- `lib/blog.test.ts` — 35 tests in total for the image surface: `parseImage` (1 absent + 7 accepted shapes incl. mixed-case-preserved and query+fragment+port + a "resolved URL is parseable, no `//` in pathname" invariant + 16 invalid shapes incl. host-less and malformed-authority cases + 3 specific-message assertions locking the "is not a valid URL" phrasing), `buildOgImages` (2), `postImageUrl` (2), `ogCardSlugs` (3), plus an `image` invariant loop in the existing `listPosts metadata` describe block.
- `app/blog/[slug]/page.tsx` — `generateMetadata` calls `buildOgImages(post)` and JSON-LD `BlogPosting.image` calls `postImageUrl(post, postUrl)`. The OG/Twitter `images` shape and the override-vs-fallback selection live in the helpers, not inline.
- `public/_headers` — pins `Content-Type: image/png` for `/blog/*/opengraph-image`. The emitted file is extensionless and Cloudflare assigns Content-Type by extension; without this, the global `X-Content-Type-Options: nosniff` would have scrapers reject it as `application/octet-stream`. Forward-compat note explains the rule's dependency on Next's extensionless emission so a future Next major bump revisits it.

## Verification

- `pnpm lint && pnpm format:check && pnpm test && pnpm build` all green; **81 / 81** tests passing.
- **Default path** (no `image:` in any post): route table lists `/blog/[slug]/opengraph-image` for all 3 slugs; emitted `<head>` per slug contains per-slug `og:image` (with cache-busting hash), `og:image:width / height / type / alt`, the `twitter:image*` mirrors, and JSON-LD `"image":"https://decdn.org/blog/<slug>/opengraph-image"`.
- **Override smoke test** (temp `image: /blog-cards/test-override.png` on one post, then reverted): `og:image` / `twitter:image` / JSON-LD `image` all flipped to `https://decdn.org/blog-cards/test-override.png`; `og:image:alt` / `twitter:image:alt` became the post title; the slug dropped out of the OG route table and no PNG was emitted for it.
- **Error-path smoke tests** (temp invalid frontmatter, then reverted):
  - `image: foo.png` → build fails with `[blog] <filename>: frontmatter` `image` `must be a site-relative path (leading` `/` `) or an absolute http(s) URL when present`.
  - `image: http://` (host-less) → build fails with `[blog] <filename>: frontmatter` `image` `"http://" is not a valid URL — Invalid URL` (the WHATWG parser's reason surfaces).

🤖 Generated with [Claude Code](https://claude.com/claude-code)