### PR TITLE
fix(nav): drop stale dark tone on non-home routes

### DIFF
--- a/components/site/Chrome.tsx
+++ b/components/site/Chrome.tsx
@@ -127,7 +127,13 @@ export function Chrome() {
     return () => window.removeEventListener("scroll", onScroll);
   }, [pathname]);
 
-  const onDark = DARK_SECTIONS.has(active);
+  // Off-home routes (e.g. /blog/, /blog/[slug]/) render none of the
+  // observed sections, so the IO effect's bail leaves `active` carrying
+  // its last home-page value. Treat it as "intro" off-home so a stale
+  // `DARK_SECTIONS` value can't paint `text-paper` over a paper-toned
+  // page (and so the mobile drawer doesn't show a stale active section).
+  const effectiveActive = pathname === "/" ? active : "intro";
+  const onDark = DARK_SECTIONS.has(effectiveActive);
   // The toggle is portalled to <body> (see MobileMenu.tsx) and lives
   // on top of the paper panel while the drawer is open — force it to
   // paper then so its × reads against the white panel.
@@ -175,7 +181,7 @@ export function Chrome() {
 
         <ul className="hidden items-center gap-7 xl:flex">
           {NAV.map((item) => {
-            const isActive = active === item.id;
+            const isActive = effectiveActive === item.id;
             return (
               <li key={item.id}>
                 <Link
@@ -216,7 +222,7 @@ export function Chrome() {
             <span aria-hidden>→</span>
           </a>
           <MobileMenu
-            activeSection={active}
+            activeSection={effectiveActive}
             tone={toggleTone}
             onOpenChange={handleMobileOpenChange}
           />

--- a/components/site/Chrome.tsx
+++ b/components/site/Chrome.tsx
@@ -127,12 +127,15 @@ export function Chrome() {
     return () => window.removeEventListener("scroll", onScroll);
   }, [pathname]);
 
-  // Off-home routes (e.g. /blog/, /blog/[slug]/) render none of the
-  // observed sections, so the IO effect's bail leaves `active` carrying
-  // its last home-page value. Treat it as "intro" off-home so a stale
-  // `DARK_SECTIONS` value can't paint `text-paper` over a paper-toned
-  // page (and so the mobile drawer doesn't show a stale active section).
-  const effectiveActive = pathname === "/" ? active : "intro";
+  // `active` is only meaningful when (a) we're on the home page, where
+  // the IO actually observes sections, and (b) the page has scrolled
+  // past the threshold, so the IO has had a chance to fire on the new
+  // route. Off-home or at-top, fall back to "intro" — otherwise a stale
+  // `DARK_SECTIONS` value can paint `text-paper` over a paper-toned
+  // page (e.g. on /blog/, or for one frame after navigating back to /
+  // before the IO fires). The mobile drawer's active highlight reads
+  // from the same value, so it stays in sync.
+  const effectiveActive = pathname === "/" && scrolled ? active : "intro";
   const onDark = DARK_SECTIONS.has(effectiveActive);
   // The toggle is portalled to <body> (see MobileMenu.tsx) and lives
   // on top of the paper panel while the drawer is open — force it to

--- a/components/site/Chrome.tsx
+++ b/components/site/Chrome.tsx
@@ -127,14 +127,11 @@ export function Chrome() {
     return () => window.removeEventListener("scroll", onScroll);
   }, [pathname]);
 
-  // `active` is only meaningful when (a) we're on the home page, where
-  // the IO actually observes sections, and (b) the page has scrolled
-  // past the threshold, so the IO has had a chance to fire on the new
-  // route. Off-home or at-top, fall back to "intro" — otherwise a stale
-  // `DARK_SECTIONS` value can paint `text-paper` over a paper-toned
-  // page (e.g. on /blog/, or for one frame after navigating back to /
-  // before the IO fires). The mobile drawer's active highlight reads
-  // from the same value, so it stays in sync.
+  // Guard against a stale `active` landing in `DARK_SECTIONS` and painting
+  // `text-paper` over a paper-toned page: off-home the IO observes nothing,
+  // and on the first render after a client nav `active` still holds the
+  // previous route's last value until the [pathname] effects re-sync.
+  // `scrolled` doubles as a proxy for "past the intro hero".
   const effectiveActive = pathname === "/" && scrolled ? active : "intro";
   const onDark = DARK_SECTIONS.has(effectiveActive);
   // The toggle is portalled to <body> (see MobileMenu.tsx) and lives


### PR DESCRIPTION
## Summary

- Navigating from a dark-toned home section (`#compare`/`#faq`) to `/blog/` or `/blog/[slug]/` left the navbar painted in `text-paper` over a paper background — wordmark and links read as invisible.
- Root cause: `Chrome.tsx`'s IO effect early-returns on routes with no observed sections, so `active` (and the `onDark` derived from it) carried the last home-page value across the client-side nav.
- Fix: at render, derive `effectiveActive = pathname === "/" && scrolled ? active : "intro"` and drive the tone, the desktop nav highlight, and `<MobileMenu activeSection>` from it. The `&& scrolled` clause also covers the reverse direction — navigating back from `/blog/` to `/` would otherwise flash dark for several frames until the IO fires its first callback on the new route. The issue's primary suggestion (`setActive("intro")` inside the effect) is rejected by eslint's `react-hooks/set-state-in-effect`, so this PR takes the alternative the issue also describes.

Closes #112

## Review follow-ups

- Gemini flagged that `pathname === "/"` is fragile under i18n / `basePath`. True but speculative — the repo has neither, and `next.config.ts` only sets `output: "export"` and `trailingSlash: true`. Tracked as #115 so the assumption is documented if either ever lands.
- Internal review: extract `effectiveActive` into a pure `resolveActiveSection(pathname, scrolled, observed, fallback)` helper and unit-test it. Out of scope here (the repo has no component-test infra and the bug is one ternary), tracked as #117 with a test-case sketch.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm test` (81/81)
- [x] `pnpm format:check`
- [x] `pnpm build` (static export)
- [ ] Manual: scroll to `#compare`/`#faq` on `/`, click "Blog" — navbar reads ink on paper on `/blog/` and `/blog/[slug]/`.
- [ ] Manual: from `/blog/`, click the wordmark or any `/#…` link to return home — no dark flash on the paper hero.
- [ ] Manual: open the mobile drawer on `/blog/` — "intro" is the highlighted active section, not `compare`/`faq`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)