### PR TITLE
fix: prevent nav hash duplication on repeated click → reload → click

### DIFF
--- a/components/site/Chrome.tsx
+++ b/components/site/Chrome.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { links } from "@/lib/links";
-import { homeHashSectionId, scrollToAnchor } from "@/lib/scroll";
+import { homeHashSectionId } from "@/lib/scroll";
 import { MobileMenu } from "@/components/site/MobileMenu";
 
 const SECTION_IDS = ["intro", "compare", "method", "faq", "contact"] as const;
@@ -72,7 +72,11 @@ export function Chrome() {
       // Write the exact single hash so it can never accumulate;
       // replaceState keeps a same-hash click a URL no-op.
       history.replaceState(null, "", `#${id}`);
-      scrollToAnchor(el);
+      // Native smooth scroll: with <html>'s motion-safe:scroll-smooth
+      // this is the browser's eased curve (the pre-fix feel), respects
+      // each section's scroll-mt, and auto-honours reduced-motion. No
+      // body pin on desktop, so the drawer's custom rAF isn't needed.
+      el.scrollIntoView({ block: "start" });
     },
     [],
   );

--- a/components/site/Chrome.tsx
+++ b/components/site/Chrome.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { links } from "@/lib/links";
+import { homeHashSectionId, scrollToAnchor } from "@/lib/scroll";
 import { MobileMenu } from "@/components/site/MobileMenu";
 
 const SECTION_IDS = ["intro", "compare", "method", "faq", "contact"] as const;
@@ -40,6 +41,39 @@ export function Chrome() {
 
   const handleMobileOpenChange = useCallback(
     (open: boolean) => setMobileOpen(open),
+    [],
+  );
+
+  // Plain `<Link href="/#section">` clicks append the hash rather than
+  // replace it when the URL already carries it (Next 16 App Router under
+  // output: "export" + trailingSlash), growing `/#method#method#method…`
+  // across click → reload → click cycles (#116). Intercept same-page
+  // anchor clicks and resolve them locally, mirroring MobileMenu's
+  // handleClick. Modified clicks (new tab, middle-click) and cross-route
+  // clicks (the section isn't on this page, e.g. /blog/*) fall through to
+  // the native <Link>, preserving the rationale behind the `/#` hrefs.
+  const handleNavClick = useCallback(
+    (e: React.MouseEvent<HTMLAnchorElement>) => {
+      if (
+        e.defaultPrevented ||
+        e.button !== 0 ||
+        e.metaKey ||
+        e.ctrlKey ||
+        e.shiftKey ||
+        e.altKey
+      ) {
+        return;
+      }
+      const id = homeHashSectionId(e.currentTarget.getAttribute("href") ?? "");
+      if (id === null) return;
+      const el = document.getElementById(id);
+      if (el === null) return;
+      e.preventDefault();
+      // Write the exact single hash so it can never accumulate;
+      // replaceState keeps a same-hash click a URL no-op.
+      history.replaceState(null, "", `#${id}`);
+      scrollToAnchor(el);
+    },
     [],
   );
 
@@ -153,6 +187,7 @@ export function Chrome() {
       <div className="mx-auto grid w-full max-w-[var(--frame-max)] grid-cols-[1fr_auto_1fr] items-center gap-4">
         <Link
           href="/#intro"
+          onClick={handleNavClick}
           className="col-start-1 flex items-center gap-3 no-underline"
         >
           {/* Both variants stay mounted and toggled via `display` so the
@@ -186,6 +221,7 @@ export function Chrome() {
               <li key={item.id}>
                 <Link
                   href={`/#${item.id}`}
+                  onClick={handleNavClick}
                   aria-current={isActive ? "true" : undefined}
                   className="nav-item"
                 >

--- a/components/site/Chrome.tsx
+++ b/components/site/Chrome.tsx
@@ -44,14 +44,14 @@ export function Chrome() {
     [],
   );
 
-  // Plain `<Link href="/#section">` clicks append the hash rather than
-  // replace it when the URL already carries it (Next 16 App Router under
-  // output: "export" + trailingSlash), growing `/#method#method#method…`
-  // across click → reload → click cycles (#116). Intercept same-page
-  // anchor clicks and resolve them locally, mirroring MobileMenu's
-  // handleClick. Modified clicks (new tab, middle-click) and cross-route
-  // clicks (the section isn't on this page, e.g. /blog/*) fall through to
-  // the native <Link>, preserving the rationale behind the `/#` hrefs.
+  // Plain `<Link href="/#section">` appends rather than replaces the hash
+  // when the URL already carries it (Next 16 App Router, output: "export"
+  // + trailingSlash), growing `/#method#method…` across click → reload →
+  // click cycles. Intercept same-page anchors and resolve locally. Off
+  // this route the section isn't in the DOM (e.g. /blog/*); force a full
+  // reload so the destination resolves the hash deterministically — the
+  // soft-nav hash codepath is the unreliable one. Modified clicks (new
+  // tab, middle-click) fall through to the native <Link>.
   const handleNavClick = useCallback(
     (e: React.MouseEvent<HTMLAnchorElement>) => {
       if (
@@ -66,16 +66,19 @@ export function Chrome() {
       }
       const id = homeHashSectionId(e.currentTarget.getAttribute("href") ?? "");
       if (id === null) return;
-      const el = document.getElementById(id);
-      if (el === null) return;
       e.preventDefault();
+      const el = document.getElementById(id);
+      if (el === null) {
+        window.location.assign(`/#${id}`);
+        return;
+      }
       // Write the exact single hash so it can never accumulate;
       // replaceState keeps a same-hash click a URL no-op.
       history.replaceState(null, "", `#${id}`);
       // Native smooth scroll: with <html>'s motion-safe:scroll-smooth
-      // this is the browser's eased curve (the pre-fix feel), respects
-      // each section's scroll-mt, and auto-honours reduced-motion. No
-      // body pin on desktop, so the drawer's custom rAF isn't needed.
+      // this is the browser's eased curve, respects each section's
+      // scroll-mt, and auto-honours reduced-motion. No body pin on
+      // desktop, so the drawer's custom rAF isn't needed.
       el.scrollIntoView({ block: "start" });
     },
     [],

--- a/components/site/MobileMenu.tsx
+++ b/components/site/MobileMenu.tsx
@@ -9,6 +9,7 @@ import {
 } from "react";
 import { createPortal } from "react-dom";
 import { links } from "@/lib/links";
+import { scrollToAnchor } from "@/lib/scroll";
 
 type SectionId = "intro" | "compare" | "method" | "faq" | "contact";
 
@@ -39,56 +40,6 @@ const EXTERNAL: readonly DrawerLink[] = [
 
 const FOCUSABLE_SELECTOR =
   'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])';
-
-// `<html>` scroll-behavior is forced to `auto` for the lifetime of
-// the rAF: without it, each per-frame `window.scrollTo` defers to
-// `motion-safe:scroll-smooth` and queues yet another browser
-// smooth-scroll per tick, which fights the rAF and reads as a
-// lumpy "slow then sudden" scroll. The loop is single-flight — a
-// new call cancels any in-flight rAF and eagerly restores its
-// captured scroll-behavior so we never snapshot the polluted
-// "auto" value (which would otherwise survive past the helper and
-// permanently override the page's CSS scroll-smooth).
-let scrollAnchorRaf = 0;
-let scrollAnchorRestore: (() => void) | null = null;
-
-function scrollToAnchor(el: HTMLElement) {
-  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
-    el.scrollIntoView({ block: "start" });
-    return;
-  }
-  if (scrollAnchorRaf !== 0) {
-    cancelAnimationFrame(scrollAnchorRaf);
-    scrollAnchorRestore?.();
-    scrollAnchorRaf = 0;
-    scrollAnchorRestore = null;
-  }
-  const startY = window.scrollY;
-  const marginTop = parseFloat(getComputedStyle(el).scrollMarginTop);
-  const targetY = startY + el.getBoundingClientRect().top - marginTop;
-  const distance = targetY - startY;
-  if (distance === 0) return;
-  const html = document.documentElement;
-  const prevScrollBehavior = html.style.scrollBehavior;
-  html.style.scrollBehavior = "auto";
-  scrollAnchorRestore = () => {
-    html.style.scrollBehavior = prevScrollBehavior;
-  };
-  const duration = 600;
-  const startTime = performance.now();
-  const tick = (now: number) => {
-    const t = Math.min(1, (now - startTime) / duration);
-    window.scrollTo(0, startY + distance * t);
-    if (t < 1) {
-      scrollAnchorRaf = requestAnimationFrame(tick);
-    } else {
-      scrollAnchorRestore?.();
-      scrollAnchorRestore = null;
-      scrollAnchorRaf = 0;
-    }
-  };
-  scrollAnchorRaf = requestAnimationFrame(tick);
-}
 
 // Hydration gate for the createPortal target. Reads false on the
 // server and true after hydration, without a useState+useEffect

--- a/lib/scroll.test.ts
+++ b/lib/scroll.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { homeHashSectionId } from "./scroll";
+
+describe("homeHashSectionId", () => {
+  it("returns the section id for a home-page hash href", () => {
+    expect(homeHashSectionId("/#method")).toBe("method");
+    expect(homeHashSectionId("/#intro")).toBe("intro");
+    expect(homeHashSectionId("/#contact")).toBe("contact");
+  });
+
+  it("returns null when there is no target section", () => {
+    expect(homeHashSectionId("/#")).toBeNull();
+    expect(homeHashSectionId("/")).toBeNull();
+  });
+
+  it("returns null for a bare hash (resolves against current URL, not home)", () => {
+    expect(homeHashSectionId("#method")).toBeNull();
+  });
+
+  it("returns null for cross-route navigation", () => {
+    expect(homeHashSectionId("/blog/foo")).toBeNull();
+    expect(homeHashSectionId("/blog/foo/#method")).toBeNull();
+  });
+});

--- a/lib/scroll.test.ts
+++ b/lib/scroll.test.ts
@@ -21,4 +21,10 @@ describe("homeHashSectionId", () => {
     expect(homeHashSectionId("/blog/foo")).toBeNull();
     expect(homeHashSectionId("/blog/foo/#method")).toBeNull();
   });
+
+  it("does not sanitize multi-hash or trailing-slash input (callers pass clean ids)", () => {
+    expect(homeHashSectionId("/#method#method")).toBe("method#method");
+    expect(homeHashSectionId("/#intro/")).toBe("intro/");
+    expect(homeHashSectionId("/?x=1#method")).toBeNull();
+  });
 });

--- a/lib/scroll.ts
+++ b/lib/scroll.ts
@@ -1,12 +1,14 @@
 // Returns the section id for a home-page hash href, or null when the href
 // is not an in-page anchor we should resolve locally.
 //
-//   "/#method"      -> "method"
-//   "/#"  | "/"     -> null   (no target section)
-//   "#method"       -> null   (bare hash — resolves against the current
-//                              URL, not the home page; not our concern)
-//   "/blog/foo"     -> null   (cross-route navigation)
+//   "/#method"          -> "method"
+//   "/#"  | "/"         -> null   (no target section)
+//   "#method"           -> null   (bare hash — resolves against the
+//                                  current URL, not home; not our concern)
+//   "/blog/foo/#method" -> null   (cross-route navigation)
 //
+// Callers pass a clean `/#${id}`; this does not sanitize multi-hash or
+// trailing-slash input (`/#a#b` -> "a#b", `/#intro/` -> "intro/").
 // Pure and DOM-free so the desktop nav click decision is unit-testable.
 export function homeHashSectionId(href: string): string | null {
   if (!href.startsWith("/#")) return null;
@@ -24,10 +26,9 @@ export function homeHashSectionId(href: string): string | null {
 // "auto" value (which would otherwise survive past the helper and
 // permanently override the page's CSS scroll-smooth).
 //
-// The state is module-level and shared by every caller (the desktop
-// nav in Chrome.tsx and the mobile drawer in MobileMenu.tsx): a nav
-// click mid drawer-close scroll cancels and restores cleanly instead
-// of the two fighting each other.
+// State is module-level so a re-entrant call — a second anchor jump
+// before the first settles — cancels the in-flight rAF and restores
+// scroll-behavior before snapshotting, rather than two loops fighting.
 let scrollAnchorRaf = 0;
 let scrollAnchorRestore: (() => void) | null = null;
 

--- a/lib/scroll.ts
+++ b/lib/scroll.ts
@@ -1,0 +1,70 @@
+// Returns the section id for a home-page hash href, or null when the href
+// is not an in-page anchor we should resolve locally.
+//
+//   "/#method"      -> "method"
+//   "/#"  | "/"     -> null   (no target section)
+//   "#method"       -> null   (bare hash — resolves against the current
+//                              URL, not the home page; not our concern)
+//   "/blog/foo"     -> null   (cross-route navigation)
+//
+// Pure and DOM-free so the desktop nav click decision is unit-testable.
+export function homeHashSectionId(href: string): string | null {
+  if (!href.startsWith("/#")) return null;
+  const id = href.slice(2);
+  return id.length > 0 ? id : null;
+}
+
+// `<html>` scroll-behavior is forced to `auto` for the lifetime of
+// the rAF: without it, each per-frame `window.scrollTo` defers to
+// `motion-safe:scroll-smooth` and queues yet another browser
+// smooth-scroll per tick, which fights the rAF and reads as a
+// lumpy "slow then sudden" scroll. The loop is single-flight — a
+// new call cancels any in-flight rAF and eagerly restores its
+// captured scroll-behavior so we never snapshot the polluted
+// "auto" value (which would otherwise survive past the helper and
+// permanently override the page's CSS scroll-smooth).
+//
+// The state is module-level and shared by every caller (the desktop
+// nav in Chrome.tsx and the mobile drawer in MobileMenu.tsx): a nav
+// click mid drawer-close scroll cancels and restores cleanly instead
+// of the two fighting each other.
+let scrollAnchorRaf = 0;
+let scrollAnchorRestore: (() => void) | null = null;
+
+export function scrollToAnchor(el: HTMLElement) {
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+    el.scrollIntoView({ block: "start" });
+    return;
+  }
+  if (scrollAnchorRaf !== 0) {
+    cancelAnimationFrame(scrollAnchorRaf);
+    scrollAnchorRestore?.();
+    scrollAnchorRaf = 0;
+    scrollAnchorRestore = null;
+  }
+  const startY = window.scrollY;
+  const marginTop = parseFloat(getComputedStyle(el).scrollMarginTop);
+  const targetY = startY + el.getBoundingClientRect().top - marginTop;
+  const distance = targetY - startY;
+  if (distance === 0) return;
+  const html = document.documentElement;
+  const prevScrollBehavior = html.style.scrollBehavior;
+  html.style.scrollBehavior = "auto";
+  scrollAnchorRestore = () => {
+    html.style.scrollBehavior = prevScrollBehavior;
+  };
+  const duration = 600;
+  const startTime = performance.now();
+  const tick = (now: number) => {
+    const t = Math.min(1, (now - startTime) / duration);
+    window.scrollTo(0, startY + distance * t);
+    if (t < 1) {
+      scrollAnchorRaf = requestAnimationFrame(tick);
+    } else {
+      scrollAnchorRestore?.();
+      scrollAnchorRestore = null;
+      scrollAnchorRaf = 0;
+    }
+  };
+  scrollAnchorRaf = requestAnimationFrame(tick);
+}


### PR DESCRIPTION
## Summary

Fixes #116. On the home page, clicking the wordmark or a desktop nav section link, hard-reloading, then clicking the same link again grew the URL fragment (`/#method#method#method…`) every cycle — invalid hash, no scroll on later loads, unshareable URL.

Plain `next/link` `<Link href="/#section">` clicks appended the hash instead of replacing it when the URL already carried it (Next 16 App Router under `output: "export"` + `trailingSlash: true`). The mobile drawer was unaffected because it already intercepts.

## Changes

- **`lib/scroll.ts`** (new) — `scrollToAnchor` + its single-flight rAF state moved verbatim out of `MobileMenu.tsx`; `MobileMenu` is its only caller (desktop uses native `scrollIntoView`). Adds pure, DOM-free `homeHashSectionId(href)`.
- **`lib/scroll.test.ts`** (new) — vitest unit tests for `homeHashSectionId`, including the unsanitized multi-hash / trailing-slash contract (callers always pass a clean `/#${id}`).
- **`components/site/MobileMenu.tsx`** — removed the local copy, imports from `@/lib/scroll`; behaviour unchanged.
- **`components/site/Chrome.tsx`** — `handleNavClick` on the wordmark + section Links: bails on modified clicks (new tab / middle-click) so the native `<Link>` handles them; for same-page anchors `preventDefault` + `history.replaceState(null, "", "#"+id)` (exact single hash — can't accumulate) + native `scrollIntoView`; for cross-route anchors (section absent, e.g. `/blog/*`) `preventDefault` + `window.location.assign("/#"+id)`, a full reload so the destination resolves the hash deterministically — matching the mobile drawer's deliberate mitigation rather than re-entering the unreliable soft-nav hash path.

`replaceState` (not `pushState`) is deliberate — a same-hash click should be a URL no-op, matching the existing MobileMenu precedent.

## Review remediation (post bot + multi-agent review)

- Cross-route `el === null` now does a full reload instead of silently falling through to the buggy native soft-nav (was an asymmetry vs `MobileMenu.tsx`).
- Removed a factually wrong "shared by every caller" comment in `lib/scroll.ts` (only the drawer calls `scrollToAnchor`).
- Pinned `homeHashSectionId`'s unsanitized-input contract with assertions + a header note.
- Tightened `Chrome.tsx` comments per `AGENTS.md` (dropped issue/caller refs and transitional phrasing).

Tracked, out of scope here: #119 (focus/a11y parity on hash-anchor click, pre-existing), #120 (extract `shouldInterceptNavClick` pure predicate), #121 (Gemini's quadratic easing + `window.scrollX` for `scrollToAnchor`).

## Verification

- `pnpm test` — 86 passed (incl. the new `homeHashSectionId` contract cases)
- `pnpm lint` — clean
- `pnpm format:check` — clean
- `pnpm build` — static export succeeded

⚠️ Still needs manual browser verification on the preview: click → hard-reload → click loop (×4–5) no longer accumulates; modifier clicks open a new tab; from `/blog/<slug>/` a desktop nav `/#method` click lands on `/` at `#method` with a single clean hash; mobile drawer regression check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)