### PR TITLE
fix(nav): PR #118 follow-ups (#119, #120, #121)

### DIFF
--- a/components/site/Chrome.tsx
+++ b/components/site/Chrome.tsx
@@ -71,6 +71,12 @@ export function Chrome() {
       // scroll-mt, and auto-honours reduced-motion. No body pin on
       // desktop, so the drawer's custom rAF isn't needed.
       el.scrollIntoView({ block: "start" });
+      // Unlike a real anchor nav, the intercepted scroll doesn't move
+      // keyboard / SR focus — without this, tab order and the reading
+      // cursor stay stuck on the nav. preventScroll so .focus() doesn't
+      // jump past the in-flight smooth scroll.
+      el.setAttribute("tabindex", "-1");
+      el.focus({ preventScroll: true });
     },
     [],
   );

--- a/components/site/Chrome.tsx
+++ b/components/site/Chrome.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { links } from "@/lib/links";
-import { homeHashSectionId } from "@/lib/scroll";
+import { homeHashSectionId, shouldInterceptNavClick } from "@/lib/scroll";
 import { MobileMenu } from "@/components/site/MobileMenu";
 
 const SECTION_IDS = ["intro", "compare", "method", "faq", "contact"] as const;
@@ -54,16 +54,7 @@ export function Chrome() {
   // tab, middle-click) fall through to the native <Link>.
   const handleNavClick = useCallback(
     (e: React.MouseEvent<HTMLAnchorElement>) => {
-      if (
-        e.defaultPrevented ||
-        e.button !== 0 ||
-        e.metaKey ||
-        e.ctrlKey ||
-        e.shiftKey ||
-        e.altKey
-      ) {
-        return;
-      }
+      if (!shouldInterceptNavClick(e)) return;
       const id = homeHashSectionId(e.currentTarget.getAttribute("href") ?? "");
       if (id === null) return;
       e.preventDefault();

--- a/components/site/Chrome.tsx
+++ b/components/site/Chrome.tsx
@@ -73,9 +73,11 @@ export function Chrome() {
       el.scrollIntoView({ block: "start" });
       // Unlike a real anchor nav, the intercepted scroll doesn't move
       // keyboard / SR focus — without this, tab order and the reading
-      // cursor stay stuck on the nav. preventScroll so .focus() doesn't
-      // jump past the in-flight smooth scroll.
-      el.setAttribute("tabindex", "-1");
+      // cursor stay stuck on the nav. Only add tabindex when the target
+      // isn't already focusable, so a focusable el isn't pulled out of
+      // tab order; leaving -1 on a section is the standard pattern.
+      // preventScroll so .focus() doesn't jump past the smooth scroll.
+      if (el.tabIndex < 0) el.setAttribute("tabindex", "-1");
       el.focus({ preventScroll: true });
     },
     [],

--- a/components/site/Chrome.tsx
+++ b/components/site/Chrome.tsx
@@ -73,10 +73,12 @@ export function Chrome() {
       el.scrollIntoView({ block: "start" });
       // Unlike a real anchor nav, the intercepted scroll doesn't move
       // keyboard / SR focus — without this, tab order and the reading
-      // cursor stay stuck on the nav. Only add tabindex when the target
-      // isn't already focusable, so a focusable el isn't pulled out of
-      // tab order; leaving -1 on a section is the standard pattern.
-      // preventScroll so .focus() doesn't jump past the smooth scroll.
+      // cursor stay stuck on the nav. Add tabindex only when the target
+      // isn't already focusable (don't pull a focusable el out of tab
+      // order); leaving the injected tabindex="-1" in place is the
+      // established programmatic-focus pattern (focusable via script,
+      // not via Tab). preventScroll so .focus() doesn't run its own
+      // scroll and race the scrollIntoView above.
       if (el.tabIndex < 0) el.setAttribute("tabindex", "-1");
       el.focus({ preventScroll: true });
     },

--- a/components/site/MobileMenu.tsx
+++ b/components/site/MobileMenu.tsx
@@ -187,9 +187,11 @@ export function MobileMenu({ activeSection, tone, onOpenChange }: Props) {
         history.replaceState(null, "", `#${anchor}`);
         scrollToAnchor(targetEl);
         // Move keyboard / SR focus into the section — scrollToAnchor
-        // only moves the viewport. preventScroll so .focus() doesn't
-        // jump past the in-flight rAF scroll.
-        targetEl.setAttribute("tabindex", "-1");
+        // only moves the viewport. Guard the tabindex so an already-
+        // focusable target isn't pulled out of tab order; leaving -1
+        // on a section is the standard pattern. preventScroll so
+        // .focus() doesn't jump past the in-flight rAF scroll.
+        if (targetEl.tabIndex < 0) targetEl.setAttribute("tabindex", "-1");
         targetEl.focus({ preventScroll: true });
       }
     };

--- a/components/site/MobileMenu.tsx
+++ b/components/site/MobileMenu.tsx
@@ -186,6 +186,11 @@ export function MobileMenu({ activeSection, tone, onOpenChange }: Props) {
         // scrollToAnchor does the visible scroll.
         history.replaceState(null, "", `#${anchor}`);
         scrollToAnchor(targetEl);
+        // Move keyboard / SR focus into the section — scrollToAnchor
+        // only moves the viewport. preventScroll so .focus() doesn't
+        // jump past the in-flight rAF scroll.
+        targetEl.setAttribute("tabindex", "-1");
+        targetEl.focus({ preventScroll: true });
       }
     };
   }, [open]);

--- a/components/site/MobileMenu.tsx
+++ b/components/site/MobileMenu.tsx
@@ -77,6 +77,11 @@ export function MobileMenu({ activeSection, tone, onOpenChange }: Props) {
   // scroll to that target instead of restoring the prior scroll
   // position — otherwise the body unlock would override the anchor jump.
   const pendingAnchorRef = useRef<string | null>(null);
+  // An anchor-select close moves focus into the target section from the
+  // Effect-A cleanup, which runs *before* the toggle-refocus effect's
+  // setup in the same commit. This flag — set there, consumed there —
+  // stops that effect from yanking focus back to the hamburger.
+  const focusMovedToSectionRef = useRef(false);
 
   useEffect(() => {
     onOpenChange(open);
@@ -187,12 +192,14 @@ export function MobileMenu({ activeSection, tone, onOpenChange }: Props) {
         history.replaceState(null, "", `#${anchor}`);
         scrollToAnchor(targetEl);
         // Move keyboard / SR focus into the section — scrollToAnchor
-        // only moves the viewport. Guard the tabindex so an already-
-        // focusable target isn't pulled out of tab order; leaving -1
-        // on a section is the standard pattern. preventScroll so
-        // .focus() doesn't jump past the in-flight rAF scroll.
+        // only moves the viewport. Add tabindex only when the target
+        // isn't already focusable (don't pull a focusable el out of
+        // tab order); leaving the injected tabindex="-1" in place is
+        // the established programmatic-focus pattern. preventScroll so
+        // .focus() doesn't race the in-flight rAF scroll.
         if (targetEl.tabIndex < 0) targetEl.setAttribute("tabindex", "-1");
         targetEl.focus({ preventScroll: true });
+        focusMovedToSectionRef.current = true;
       }
     };
   }, [open]);
@@ -202,7 +209,14 @@ export function MobileMenu({ activeSection, tone, onOpenChange }: Props) {
   const wasOpenRef = useRef(false);
   useEffect(() => {
     if (wasOpenRef.current && !open) {
-      toggleRef.current?.focus({ preventScroll: true });
+      // An anchor-select close already moved focus into the section;
+      // leave it there. Normal closes (Escape, scrim, toggle, resize)
+      // leave the flag false and still return focus to the toggle.
+      if (focusMovedToSectionRef.current) {
+        focusMovedToSectionRef.current = false;
+      } else {
+        toggleRef.current?.focus({ preventScroll: true });
+      }
     }
     wasOpenRef.current = open;
   }, [open]);

--- a/lib/scroll.test.ts
+++ b/lib/scroll.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { homeHashSectionId } from "./scroll";
+import { homeHashSectionId, shouldInterceptNavClick } from "./scroll";
 
 describe("homeHashSectionId", () => {
   it("returns the section id for a home-page hash href", () => {
@@ -26,5 +26,47 @@ describe("homeHashSectionId", () => {
     expect(homeHashSectionId("/#method#method")).toBe("method#method");
     expect(homeHashSectionId("/#intro/")).toBe("intro/");
     expect(homeHashSectionId("/?x=1#method")).toBeNull();
+  });
+});
+
+describe("shouldInterceptNavClick", () => {
+  const plainLeftClick = {
+    defaultPrevented: false,
+    button: 0,
+    metaKey: false,
+    ctrlKey: false,
+    shiftKey: false,
+    altKey: false,
+  };
+
+  it("intercepts a plain left-click", () => {
+    expect(shouldInterceptNavClick(plainLeftClick)).toBe(true);
+  });
+
+  it("does not intercept an already-prevented click", () => {
+    expect(
+      shouldInterceptNavClick({ ...plainLeftClick, defaultPrevented: true }),
+    ).toBe(false);
+  });
+
+  it("does not intercept a non-primary button (e.g. middle-click)", () => {
+    expect(shouldInterceptNavClick({ ...plainLeftClick, button: 1 })).toBe(
+      false,
+    );
+  });
+
+  it("does not intercept a modified click (new tab / new window)", () => {
+    expect(shouldInterceptNavClick({ ...plainLeftClick, metaKey: true })).toBe(
+      false,
+    );
+    expect(shouldInterceptNavClick({ ...plainLeftClick, ctrlKey: true })).toBe(
+      false,
+    );
+    expect(shouldInterceptNavClick({ ...plainLeftClick, shiftKey: true })).toBe(
+      false,
+    );
+    expect(shouldInterceptNavClick({ ...plainLeftClick, altKey: true })).toBe(
+      false,
+    );
   });
 });

--- a/lib/scroll.ts
+++ b/lib/scroll.ts
@@ -66,6 +66,9 @@ export function scrollToAnchor(el: HTMLElement) {
     scrollAnchorRestore = null;
   }
   const startY = window.scrollY;
+  // Captured once (symmetric with startY) so a horizontal scroll mid-
+  // animation can't yank the page sideways; this loop only moves Y.
+  const startX = window.scrollX;
   const marginTop = parseFloat(getComputedStyle(el).scrollMarginTop);
   const targetY = startY + el.getBoundingClientRect().top - marginTop;
   const distance = targetY - startY;
@@ -80,7 +83,10 @@ export function scrollToAnchor(el: HTMLElement) {
   const startTime = performance.now();
   const tick = (now: number) => {
     const t = Math.min(1, (now - startTime) / duration);
-    window.scrollTo(0, startY + distance * t);
+    // Quadratic ease-in-out — linear reads mechanical next to the
+    // browser's native eased curve.
+    const ease = t < 0.5 ? 2 * t * t : -1 + (4 - 2 * t) * t;
+    window.scrollTo(startX, startY + distance * ease);
     if (t < 1) {
       scrollAnchorRaf = requestAnimationFrame(tick);
     } else {

--- a/lib/scroll.ts
+++ b/lib/scroll.ts
@@ -18,8 +18,9 @@ export function homeHashSectionId(href: string): string | null {
 
 // Whether a nav click should be intercepted for local hash resolution,
 // vs. falling through to the native <Link> (modified clicks: new tab,
-// middle-click, etc. — generic browser-nav etiquette). Pure so the
-// desktop handler's guard is unit-testable; the DOM glue stays untested.
+// middle-click, etc. — generic browser-nav etiquette). `button` is the
+// DOM MouseEvent.button enum; only 0 (primary) is intercepted. Pure so
+// the desktop handler's guard is unit-testable; DOM glue stays untested.
 export function shouldInterceptNavClick(e: {
   defaultPrevented: boolean;
   button: number;
@@ -80,10 +81,11 @@ export function scrollToAnchor(el: HTMLElement) {
   const startTime = performance.now();
   const tick = (now: number) => {
     const t = Math.min(1, (now - startTime) / duration);
-    // Quadratic ease-in-out — linear reads mechanical next to the
-    // browser's native eased curve. scrollX is read live each frame
-    // (not pinned to a captured value) so a horizontal scroll mid-
-    // animation isn't fought; this loop only drives Y.
+    // Quadratic ease-in-out so the programmatic scroll doesn't read
+    // mechanically (linear feels robotic). scrollX is re-read each
+    // frame rather than hard-coded to 0, so this Y-only loop preserves
+    // the current horizontal position instead of snapping to the left
+    // edge.
     const ease = t < 0.5 ? 2 * t * t : -1 + (4 - 2 * t) * t;
     window.scrollTo(window.scrollX, startY + distance * ease);
     if (t < 1) {

--- a/lib/scroll.ts
+++ b/lib/scroll.ts
@@ -16,6 +16,28 @@ export function homeHashSectionId(href: string): string | null {
   return id.length > 0 ? id : null;
 }
 
+// Whether a nav click should be intercepted for local hash resolution,
+// vs. falling through to the native <Link> (modified clicks: new tab,
+// middle-click, etc. — generic browser-nav etiquette). Pure so the
+// desktop handler's guard is unit-testable; the DOM glue stays untested.
+export function shouldInterceptNavClick(e: {
+  defaultPrevented: boolean;
+  button: number;
+  metaKey: boolean;
+  ctrlKey: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+}): boolean {
+  return !(
+    e.defaultPrevented ||
+    e.button !== 0 ||
+    e.metaKey ||
+    e.ctrlKey ||
+    e.shiftKey ||
+    e.altKey
+  );
+}
+
 // `<html>` scroll-behavior is forced to `auto` for the lifetime of
 // the rAF: without it, each per-frame `window.scrollTo` defers to
 // `motion-safe:scroll-smooth` and queues yet another browser

--- a/lib/scroll.ts
+++ b/lib/scroll.ts
@@ -66,9 +66,6 @@ export function scrollToAnchor(el: HTMLElement) {
     scrollAnchorRestore = null;
   }
   const startY = window.scrollY;
-  // Captured once (symmetric with startY) so a horizontal scroll mid-
-  // animation can't yank the page sideways; this loop only moves Y.
-  const startX = window.scrollX;
   const marginTop = parseFloat(getComputedStyle(el).scrollMarginTop);
   const targetY = startY + el.getBoundingClientRect().top - marginTop;
   const distance = targetY - startY;
@@ -84,9 +81,11 @@ export function scrollToAnchor(el: HTMLElement) {
   const tick = (now: number) => {
     const t = Math.min(1, (now - startTime) / duration);
     // Quadratic ease-in-out — linear reads mechanical next to the
-    // browser's native eased curve.
+    // browser's native eased curve. scrollX is read live each frame
+    // (not pinned to a captured value) so a horizontal scroll mid-
+    // animation isn't fought; this loop only drives Y.
     const ease = t < 0.5 ? 2 * t * t : -1 + (4 - 2 * t) * t;
-    window.scrollTo(startX, startY + distance * ease);
+    window.scrollTo(window.scrollX, startY + distance * ease);
     if (t < 1) {
       scrollAnchorRaf = requestAnimationFrame(tick);
     } else {


### PR DESCRIPTION
Resolves the three standalone follow-ups filed off the [PR #118](https://github.com/decdn/website/pull/118) review. Each is a pre-existing weakness deliberately deferred so #118 stayed scoped to the #116 hash-accumulation fix — none is a regression introduced by #118. Conventional commits, bisectable.

### `shouldInterceptNavClick` extraction — Closes #120
Extracts the 6-flag modifier short-circuit from `Chrome.tsx`'s `handleNavClick` into a pure `shouldInterceptNavClick` predicate in `lib/scroll.ts`, mirroring the #114→#117 precedent. Adds a `lib/scroll.test.ts` block: plain left-click → `true`; `defaultPrevented` / middle-click / each modifier → `false`. Zero new infra (Node-env Vitest, existing glob).

### Ease `scrollToAnchor` + preserve horizontal scroll — Closes #121
`scrollToAnchor` now uses a quadratic ease-in-out instead of linear, and reads `window.scrollX` live each rAF frame (instead of the original hard-coded `0`, which would yank horizontal scroll to the left edge). Live-read — not a captured `startX` — is the deliberate choice: the loop only drives Y, so re-reading X each frame is a no-op pass-through that never fights the user (see review threads). Reduced-motion early-return, single-flight cancel/restore, and the `distance === 0` short-circuit are unchanged. Only caller is the mobile drawer's close-then-scroll.

### Move focus to section on in-page nav jump — Closes #119
The intercepted same-page jump scrolled the section into view but never moved keyboard / screen-reader focus, leaving tab order and the SR reading cursor stuck on the nav. Both call sites (desktop `handleNavClick`, mobile drawer cleanup) now set `tabindex="-1"` (guarded by `if (el.tabIndex < 0)` so an already-focusable target isn't pulled out of tab order) and `.focus({ preventScroll: true })`. On mobile, an additional `focusMovedToSectionRef` flag stops the toggle-refocus effect from yanking focus back to the hamburger after an anchor-close (its setup runs after the cleanup that moves focus, in the same commit) — without it the mobile focus move was a no-op. No CSS guard needed — `globals.css` uses `:focus-visible` only, which doesn't fire for programmatic focus.

## Review follow-ups

- Addressed gemini-code-assist inline review (scrollX live-read accepted; `tabindex` guard adopted; blur-removal cleanup declined on merit with rationale on-thread).
- `/review-pr` multi-agent pass caught a Critical regression: the mobile #119 focus was being clobbered by the existing toggle-refocus effect — fixed (the `focusMovedToSectionRef` flag above), plus comment-accuracy polish.
- #124 filed for a **pre-existing** `NaN` `scrollMarginTop` → scroll-to-top footgun (moved verbatim from #118; out of scope here, not fixed in this PR).

## Verification

- `pnpm test` — 90 passed (incl. `shouldInterceptNavClick` cases)
- `pnpm lint` / `pnpm format:check` — clean
- `pnpm build` — static export succeeds

Not auto-verifiable (needs manual / AT testing): keyboard tab-order + VoiceOver focus landing for #119 (desktop **and** mobile drawer, incl. that Escape/scrim still returns focus to the toggle), and the eased scroll feel for #121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)