### PR TITLE
fix: footer gap (#123) + scrollToAnchor NaN guard (#124)

### DIFF
--- a/components/site/Close.tsx
+++ b/components/site/Close.tsx
@@ -7,7 +7,7 @@ const wordmarkH = "clamp(4.75rem, 14vw, 11.5rem)";
 
 export function Close() {
   return (
-    <Frame id="contact" tone="paper" className="overflow-hidden">
+    <Frame id="contact" tone="paper" className="overflow-hidden" fill={false}>
       <SectionHeader
         index="05"
         label="Contact"

--- a/components/site/Footer.tsx
+++ b/components/site/Footer.tsx
@@ -2,7 +2,7 @@ import { links } from "@/lib/links";
 
 export function Footer() {
   return (
-    <footer className="bg-paper px-[var(--frame-gutter)] pt-16 pb-10 text-ink">
+    <footer className="bg-paper px-[var(--frame-gutter)] pb-10 text-ink">
       <div className="@container mx-auto flex max-w-[var(--frame-max)] flex-col gap-3">
         <span aria-hidden className="rule opacity-40" />
         <div className="grid grid-cols-1 gap-2 text-micro tracking-[0.2em] uppercase opacity-80 @md:grid-cols-3 @md:items-center">

--- a/components/ui/Frame.tsx
+++ b/components/ui/Frame.tsx
@@ -28,13 +28,16 @@ export function Frame({
   fill = true,
   children,
 }: FrameProps) {
-  const minH = fill ? "min-h-[min(100svh,var(--frame-min-h-cap))]" : "";
+  const sectionClass = [
+    "relative flex flex-col scroll-mt-[var(--nav-h)] px-[var(--frame-gutter)] py-[var(--frame-pad-y)]",
+    fill && "min-h-[min(100svh,var(--frame-min-h-cap))]",
+    TONE_CLASS[tone],
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
   return (
-    <section
-      id={id}
-      aria-labelledby={`${id}-h`}
-      className={`relative flex ${minH} scroll-mt-[var(--nav-h)] flex-col px-[var(--frame-gutter)] py-[var(--frame-pad-y)] ${TONE_CLASS[tone]} ${className}`}
-    >
+    <section id={id} aria-labelledby={`${id}-h`} className={sectionClass}>
       <div className="@container relative z-10 mx-auto flex w-full max-w-[var(--frame-max)] flex-1 flex-col">
         {children}
       </div>

--- a/components/ui/Frame.tsx
+++ b/components/ui/Frame.tsx
@@ -7,6 +7,12 @@ type FrameProps = {
   tone: Tone;
   /** Extra classes on the outer <section>. */
   className?: string;
+  /**
+   * Full-viewport min-height (default true). Set false for a
+   * content-height section, e.g. the closing section directly above
+   * the footer, where the floor would just manufacture dead space.
+   */
+  fill?: boolean;
   children: ReactNode;
 };
 
@@ -15,12 +21,19 @@ const TONE_CLASS: Record<Tone, string> = {
   paper: "bg-paper text-ink",
 };
 
-export function Frame({ id, tone, className = "", children }: FrameProps) {
+export function Frame({
+  id,
+  tone,
+  className = "",
+  fill = true,
+  children,
+}: FrameProps) {
+  const minH = fill ? "min-h-[min(100svh,var(--frame-min-h-cap))]" : "";
   return (
     <section
       id={id}
       aria-labelledby={`${id}-h`}
-      className={`relative flex min-h-[min(100svh,var(--frame-min-h-cap))] scroll-mt-[var(--nav-h)] flex-col px-[var(--frame-gutter)] py-[var(--frame-pad-y)] ${TONE_CLASS[tone]} ${className}`}
+      className={`relative flex ${minH} scroll-mt-[var(--nav-h)] flex-col px-[var(--frame-gutter)] py-[var(--frame-pad-y)] ${TONE_CLASS[tone]} ${className}`}
     >
       <div className="@container relative z-10 mx-auto flex w-full max-w-[var(--frame-max)] flex-1 flex-col">
         {children}

--- a/lib/scroll.test.ts
+++ b/lib/scroll.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { homeHashSectionId, shouldInterceptNavClick } from "./scroll";
+import {
+  homeHashSectionId,
+  parseScrollMarginTop,
+  shouldInterceptNavClick,
+} from "./scroll";
 
 describe("homeHashSectionId", () => {
   it("returns the section id for a home-page hash href", () => {
@@ -26,6 +30,26 @@ describe("homeHashSectionId", () => {
     expect(homeHashSectionId("/#method#method")).toBe("method#method");
     expect(homeHashSectionId("/#intro/")).toBe("intro/");
     expect(homeHashSectionId("/?x=1#method")).toBeNull();
+  });
+});
+
+describe("parseScrollMarginTop", () => {
+  it("parses a normal resolved px value", () => {
+    expect(parseScrollMarginTop("80px")).toBe(80);
+    expect(parseScrollMarginTop("0px")).toBe(0);
+    expect(parseScrollMarginTop("24.5px")).toBe(24.5);
+  });
+
+  it("falls back to 0 for an empty computed value (the #124 bug case)", () => {
+    expect(parseScrollMarginTop("")).toBe(0);
+  });
+
+  it("falls back to 0 for a non-numeric computed value", () => {
+    expect(parseScrollMarginTop("auto")).toBe(0);
+  });
+
+  it("tolerates leading whitespace (parseFloat semantics)", () => {
+    expect(parseScrollMarginTop("  16px ")).toBe(16);
   });
 });
 

--- a/lib/scroll.test.ts
+++ b/lib/scroll.test.ts
@@ -51,6 +51,12 @@ describe("parseScrollMarginTop", () => {
   it("tolerates leading whitespace (parseFloat semantics)", () => {
     expect(parseScrollMarginTop("  16px ")).toBe(16);
   });
+
+  it("guards finiteness only, not sign (a negative value passes through)", () => {
+    // scroll-margin-top is subtracted into live scroll math, so the
+    // helper deliberately clamps NaN — not the sign — to 0.
+    expect(parseScrollMarginTop("-8px")).toBe(-8);
+  });
 });
 
 describe("shouldInterceptNavClick", () => {

--- a/lib/scroll.ts
+++ b/lib/scroll.ts
@@ -55,6 +55,19 @@ export function shouldInterceptNavClick(e: {
 let scrollAnchorRaf = 0;
 let scrollAnchorRestore: (() => void) | null = null;
 
+// `getComputedStyle(el).scrollMarginTop` is normally a `px` string, but a
+// detached/unrendered element (or unsupported serialization) yields "" →
+// parseFloat is NaN. Unguarded, that NaN flows into `distance`; since
+// `NaN === 0` is false the no-op early return is skipped and the rAF runs
+// `scrollTo(x, NaN)`, which CSSOM-View coerces to y=0 — the page silently
+// scrolls to the top. Clamping to 0 degrades to "ignore scroll-margin" (a
+// visible, sane fallback) and restores the `distance === 0` guard's meaning.
+// Pure so it's unit-testable; the DOM read stays at the call site.
+export function parseScrollMarginTop(computed: string): number {
+  const px = parseFloat(computed);
+  return Number.isFinite(px) ? px : 0;
+}
+
 export function scrollToAnchor(el: HTMLElement) {
   if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
     el.scrollIntoView({ block: "start" });
@@ -67,7 +80,7 @@ export function scrollToAnchor(el: HTMLElement) {
     scrollAnchorRestore = null;
   }
   const startY = window.scrollY;
-  const marginTop = parseFloat(getComputedStyle(el).scrollMarginTop);
+  const marginTop = parseScrollMarginTop(getComputedStyle(el).scrollMarginTop);
   const targetY = startY + el.getBoundingClientRect().top - marginTop;
   const distance = targetY - startY;
   if (distance === 0) return;

--- a/lib/scroll.ts
+++ b/lib/scroll.ts
@@ -56,8 +56,8 @@ let scrollAnchorRaf = 0;
 let scrollAnchorRestore: (() => void) | null = null;
 
 // `getComputedStyle(el).scrollMarginTop` is normally a `px` string, but a
-// detached/unrendered element (or unsupported serialization) yields "" →
-// parseFloat is NaN. Unguarded, that NaN flows into `distance`; since
+// detached/unrendered element yields "" → parseFloat is NaN. Unguarded,
+// that NaN flows into `distance`; since
 // `NaN === 0` is false the no-op early return is skipped and the rAF runs
 // `scrollTo(x, NaN)`, which CSSOM-View coerces to y=0 — the page silently
 // scrolls to the top. Clamping to 0 degrades to "ignore scroll-margin" (a


### PR DESCRIPTION
Two independent, pre-existing bugs surfaced during the PR #122 review. One branch, one PR.

## #124 — `scrollToAnchor` jumps to top on NaN scroll-margin

`parseFloat(getComputedStyle(el).scrollMarginTop)` returns `NaN` when the computed value serializes to `""` (detached/unrendered element). The `NaN` flows into `distance`; because `NaN === 0` is false the no-op early return is skipped, the rAF runs `window.scrollTo(x, NaN)`, CSSOM-View coerces `y` to `0`, and the page silently animates to the **top** instead of the target section. Only the mobile-drawer → `scrollToAnchor` path is affected (desktop nav uses native `scrollIntoView`).

Fix: extract a pure, unit-tested `parseScrollMarginTop` helper that clamps non-finite results to `0` (finiteness only — sign is intentionally preserved). Worst case degrades to "scroll to the element ignoring its scroll-margin" — a sane, visible fallback — and the `distance === 0` guard regains its meaning. Covered in `lib/scroll.test.ts` including the `"" → 0` bug case and a negative-value contract test.

## #123 — Empty band above the footer on tall viewports

Two compounding causes:

1. **Footer's own top padding.** Dropped `pt-16` from `Footer` — the preceding `Frame` already carries generous `--frame-pad-y` (5–7rem) bottom padding on the same `bg-paper`, so the footer's own top padding was redundant.
2. **The closing section's full-height floor.** `Frame` forces every section to `min-h: min(100svh, 54rem)`. The closing (`Close`) section's content is shorter than that and top-anchored, so the leftover height collapsed into a conspicuous dead band directly above the footer — the part the footer-padding trim alone couldn't fix.

Fix for (2): added an opt-out `fill?: boolean` prop to `Frame` (default `true`, so every other section is unchanged) and set `fill={false}` on the closing section. It is now content-height; the footer sits one `--frame-pad-y` below the closing content — tight and visually balanced, no dead band.

## Review

Ran a multi-agent review (general/tests/comments/error-handling): no critical or important issues. Addressed the minor nits in `79efe85`:
- `Frame` className composed via `[...].filter(Boolean).join(" ")` (no stray double-space when `fill={false}`).
- Added a negative-value test pinning that the helper guards finiteness, not sign.
- Tightened the `scroll.ts` rationale comment to the demonstrated/tested case.

## Verification

- `pnpm test` — 95 passed
- `pnpm lint`, `pnpm format:check` — clean
- `pnpm build` — static export succeeds
- Manual: footer sits tight under the closing content on tall viewports; Hero/Comparison/Method/Faq/blog still full-bleed; `#contact` anchor unaffected

Closes #124
Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)