### PR TITLE
chore: drop primer tag from "what we're building" post

### DIFF
--- a/content/blog/00-what-were-building.mdx
+++ b/content/blog/00-what-were-building.mdx
@@ -4,7 +4,7 @@ slug: what-were-building
 date: 2026-05-04
 summary: "What deCDN is, who it's for, and what the protocol composes — a plain-English introduction."
 bucket: pillar
-tags: [primer, protocol, architecture, overview]
+tags: [protocol, architecture, overview]
 ---
 
 **decdn** is a content delivery network where there's no central operator. Bytes flow from anyone willing to serve them to anyone willing to pay for them, denominated in dollars, with cryptographic verification at the edge and no contract longer than a single megabyte. This post is the plain-English introduction.


### PR DESCRIPTION
Removes the `primer` tag from the "What We're Building" blog post.

`tags: [primer, protocol, architecture, overview]` → `tags: [protocol, architecture, overview]`

### Blast radius

Zero beyond the post's own metadata:
- No per-tag routes / no `generateStaticParams` over tags.
- No sitemap or robots references to tags.
- No other post uses `primer` (no orphaned tag page — tags don't generate pages anyway).
- Tags render only as cosmetic pills + JSON-LD `keywords`.
- `lib/blog.test.ts` mentions "primer" only as an isolated `parseTags` fixture, unrelated to this post.

### Verification

- `pnpm test` — 90/90 passed.
- `pnpm build` — static export succeeded.
- Rendered `out/blog/what-were-building/index.html`: 0 `primer` occurrences; `protocol`, `architecture`, `overview` all present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)