### PR TITLE
refactor: name section components after their section id

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ pnpm format:check     # prettier --check . (CI)
 ## Layout
 
 - `app/` — App Router entry (`layout.tsx`, `page.tsx`, `globals.css`), the `blog/` and `blog/[slug]/` routes, the `robots.ts` / `sitemap.xml/route.ts` / `sitemap-pages.xml/route.ts` handlers, and the file-convention assets (`favicon.ico`, `icon.svg`, `apple-icon.png`, `opengraph-image.{png,alt.txt}`).
-- `components/site/` — page sections composed by `app/page.tsx` (Hero, Compare, Method, Faq, Contact, …) plus chrome (`Chrome`, `Footer`, `ScrollReveal`). Section components are named after their section `id` (e.g. `Contact.tsx` → `#contact`); `Hero` is the idiomatic exception for the top `#intro` section.
+- `components/site/` — page sections composed by `app/page.tsx` (Hero, Compare, Method, Faq, Contact, …) plus chrome (`Chrome`, `Footer`, `ScrollReveal`). Section components are named after their section `id` (e.g. `Contact.tsx` for `id="contact"`); `Hero` is the idiomatic exception for the top `id="intro"` section.
 - `components/ui/` — low-level primitives (Frame, SectionHeader, Prose, Figure, …).
 - `lib/` — shared helpers (`links.ts`, `blog.ts`, `faq.ts`, `jsonld.tsx`).
 - `content/blog/` — MDX posts loaded by `lib/blog.ts` and rendered via `app/blog/[slug]/page.tsx`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ pnpm format:check     # prettier --check . (CI)
 ## Layout
 
 - `app/` — App Router entry (`layout.tsx`, `page.tsx`, `globals.css`), the `blog/` and `blog/[slug]/` routes, the `robots.ts` / `sitemap.xml/route.ts` / `sitemap-pages.xml/route.ts` handlers, and the file-convention assets (`favicon.ico`, `icon.svg`, `apple-icon.png`, `opengraph-image.{png,alt.txt}`).
-- `components/site/` — page sections composed by `app/page.tsx` (Hero, Comparison, Method, Faq, Close, …) plus chrome (`Chrome`, `Footer`, `ScrollReveal`).
+- `components/site/` — page sections composed by `app/page.tsx` (Hero, Compare, Method, Faq, Contact, …) plus chrome (`Chrome`, `Footer`, `ScrollReveal`). Section components are named after their section `id` (e.g. `Contact.tsx` → `#contact`); `Hero` is the idiomatic exception for the top `#intro` section.
 - `components/ui/` — low-level primitives (Frame, SectionHeader, Prose, Figure, …).
 - `lib/` — shared helpers (`links.ts`, `blog.ts`, `faq.ts`, `jsonld.tsx`).
 - `content/blog/` — MDX posts loaded by `lib/blog.ts` and rendered via `app/blog/[slug]/page.tsx`.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ pnpm format    # prettier --write .
 ## Project layout
 
 - `app/` — App Router entry (`layout.tsx`, `page.tsx`, `globals.css`) plus the blog routes (`blog/`, `blog/[slug]/`), sitemap/robots handlers, and file-convention metadata assets.
-- `components/site/` — page sections composed by `app/page.tsx` (Hero, Comparison, Method, Faq, Close).
+- `components/site/` — page sections composed by `app/page.tsx` (Hero, Compare, Method, Faq, Contact).
 - `components/ui/` — low-level primitives (Frame, SectionHeader, Figure, …).
 - `lib/` — shared helpers (`links.ts`, `blog.ts`, `faq.ts`, `jsonld.tsx`).
 - `content/blog/` — MDX posts loaded by `lib/blog.ts` and rendered by `app/blog/[slug]/page.tsx`.

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,5 @@
-import { Close } from "@/components/site/Close";
-import { Comparison } from "@/components/site/Comparison";
+import { Compare } from "@/components/site/Compare";
+import { Contact } from "@/components/site/Contact";
 import { Faq } from "@/components/site/Faq";
 import { Hero } from "@/components/site/Hero";
 import { Method } from "@/components/site/Method";
@@ -25,10 +25,10 @@ export default function Home() {
     <main>
       <JsonLd data={faqSchema} />
       <Hero />
-      <Comparison />
+      <Compare />
       <Method />
       <Faq />
-      <Close />
+      <Contact />
     </main>
   );
 }

--- a/components/site/Compare.tsx
+++ b/components/site/Compare.tsx
@@ -2,7 +2,7 @@ import { ComparisonRow } from "@/components/ui/ComparisonRow";
 import { Frame } from "@/components/ui/Frame";
 import { SectionHeader } from "@/components/ui/SectionHeader";
 
-export function Comparison() {
+export function Compare() {
   return (
     <Frame id="compare" tone="ink">
       <SectionHeader

--- a/components/site/Contact.tsx
+++ b/components/site/Contact.tsx
@@ -5,7 +5,7 @@ import { FleetStatus } from "@/components/site/FleetStatus";
 
 const wordmarkH = "clamp(4.75rem, 14vw, 11.5rem)";
 
-export function Close() {
+export function Contact() {
   return (
     <Frame id="contact" tone="paper" className="overflow-hidden" fill={false}>
       <SectionHeader


### PR DESCRIPTION
## Summary

Renames `components/site/` section components so the file + export match the section's domain identity (its `Frame` id / nav label) rather than its visual role in the page flow:

- `Close.tsx` → `Contact.tsx` (export `Close` → `Contact`) — renders `#contact`
- `Comparison.tsx` → `Compare.tsx` (export `Comparison` → `Compare`) — renders `#compare`

`git mv` preserves blame/history. `app/page.tsx` imports + JSX updated. The `components/site/` Layout bullet in both `AGENTS.md` and `README.md` is refreshed (the stale `Hero, Comparison, …, Close` list), and `AGENTS.md` gains a convention note so the pattern doesn't regress.

`components/ui/ComparisonRow.tsx` (a ui primitive) is intentionally left as-is — the issue scopes only `components/site/` section components.

## Blast radius

Section `id`s/nav entries are string literals in `Frame`/`Chrome.tsx`, not derived from filenames, so anchors (`/#contact`, `/#compare`), scroll, sitemap, and JSON-LD are unaffected. Only `app/page.tsx` consumed these components; no tests reference them.

## Review follow-up

- **gemini-code-assist** (`AGENTS.md` convention note): adopted the precise `id="contact"`/`id="intro"` wording instead of the URL-fragment form (bfbd969). Declined the suggestion to drop the trailing `…` — it's the Layout section's house style for representative lists and `components/site/` legitimately holds non-section files.
- **copilot-pull-request-reviewer**: no comments.
- **`/pr-review-toolkit` (code-reviewer + comment-analyzer)**: caught a stale `README.md` `components/site/` list still naming `Comparison`/`Close`; synced it to `Compare`/`Contact` (e3ad6b6). AGENTS.md note verified factually accurate against every section component. No other actionable findings.

## Verification

- `pnpm exec tsc --noEmit` — OK
- `pnpm lint` — clean
- `pnpm build` — static export succeeded
- `pnpm exec prettier --check AGENTS.md README.md` — clean (follow-up commits)
- grep: no dangling `Close`/`Comparison` import references

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)