### PR TITLE
chore: rename "legacy cdn" to "traditional cdn"

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,7 +15,7 @@ const geistSans = Geist({
 
 const TITLE = "deCDN — A peer-to-peer delivery layer for bytes at scale";
 const DESCRIPTION =
-  "A peer-to-peer CDN. Anyone can serve bytes; clients pay per megabyte in USDC. ~$0.01/GB — up to 90% cheaper than legacy networks.";
+  "A peer-to-peer CDN. Anyone can serve bytes; clients pay per megabyte in USDC. ~$0.01/GB — up to 90% cheaper than traditional networks.";
 
 export const metadata: Metadata = {
   metadataBase: new URL(links.site),

--- a/components/site/Compare.tsx
+++ b/components/site/Compare.tsx
@@ -8,7 +8,7 @@ export function Compare() {
       <SectionHeader
         index="02"
         label="Side by side"
-        timestamp="legacy vs decdn · seven axes"
+        timestamp="traditional vs decdn · seven axes"
       />
 
       <div className="mt-14 flex flex-col gap-10">
@@ -41,7 +41,9 @@ export function Compare() {
         >
           <div className="meta opacity-0 @xl:col-span-2 @xl:block">axis</div>
           <div className="grid grid-cols-2 gap-4 @xl:contents">
-            <div className="meta opacity-55 @xl:col-span-5">legacy cdn</div>
+            <div className="meta opacity-55 @xl:col-span-5">
+              traditional cdn
+            </div>
             <div className="meta @xl:col-span-5">
               decdn
               <span className="ml-2 opacity-60">/ peer-to-peer</span>
@@ -82,37 +84,37 @@ export function Compare() {
 
         <ComparisonRow
           label="delivery"
-          legacy="fixed provisioning"
+          traditional="fixed provisioning"
           decdn="demand-shaped mesh"
           delay={420}
         />
         <ComparisonRow
           label="billing"
-          legacy="monthly minimums, annual contracts"
+          traditional="monthly minimums, annual contracts"
           decdn="per megabyte, in usdc"
           delay={480}
         />
         <ComparisonRow
           label="operators"
-          legacy="three hyperscalers"
+          traditional="three hyperscalers"
           decdn="home labs to datacenters"
           delay={540}
         />
         <ComparisonRow
           label="integrity"
-          legacy="trust the origin"
+          traditional="trust the origin"
           decdn="blake3, verify every chunk"
           delay={600}
         />
         <ComparisonRow
           label="failure"
-          legacy="pop dies, region 503s"
+          traditional="pop dies, region 503s"
           decdn="peer drops, stream continues"
           delay={660}
         />
         <ComparisonRow
           label="scaling"
-          legacy="gets more expensive"
+          traditional="gets more expensive"
           decdn="gets cheaper"
           delay={720}
         />

--- a/components/ui/ComparisonRow.tsx
+++ b/components/ui/ComparisonRow.tsx
@@ -1,11 +1,11 @@
 export function ComparisonRow({
   label,
-  legacy,
+  traditional,
   decdn,
   delay = 0,
 }: {
   label: string;
-  legacy: string;
+  traditional: string;
   decdn: string;
   delay?: number;
 }) {
@@ -17,7 +17,7 @@ export function ComparisonRow({
     >
       <div className="meta opacity-60 @xl:col-span-2">{label}</div>
       <div className="grid grid-cols-2 gap-4 @xl:contents">
-        <div className="opacity-55 @xl:col-span-5">{legacy}</div>
+        <div className="opacity-55 @xl:col-span-5">{traditional}</div>
         <div className="font-semibold tracking-[-0.01em] @xl:col-span-5">
           {decdn}
         </div>

--- a/content/blog/01-why-now.mdx
+++ b/content/blog/01-why-now.mdx
@@ -53,7 +53,7 @@ The same maturity wave gave us:
 
 ## Demand caught up at the same time
 
-The supply-side primitives matured in parallel with a demand shock that didn't exist in 2020. Payload sizes grew an order of magnitude — modern open-source ML weights run 10–700GB; high-bitrate media, container images, and dataset distributions all push hundreds of GB; package archives are a hundred-fold larger than they were a decade ago. Legacy CDN list pricing didn't move: Cloudflare R2, AWS CloudFront, and Akamai are still in the $0.04–$0.20/GB band, the same as ten years ago. The teams shipping these payloads cannot run that math.
+The supply-side primitives matured in parallel with a demand shock that didn't exist in 2020. Payload sizes grew an order of magnitude — modern open-source ML weights run 10–700GB; high-bitrate media, container images, and dataset distributions all push hundreds of GB; package archives are a hundred-fold larger than they were a decade ago. Traditional CDN list pricing didn't move: Cloudflare R2, AWS CloudFront, and Akamai are still in the $0.04–$0.20/GB band, the same as ten years ago. The teams shipping these payloads cannot run that math.
 
 Centralized risk got worse, not better. A handful of hosts carry the load for industries whose entire pitch is openness. Every major release throttles incumbent CDNs within hours.
 

--- a/lib/faq.ts
+++ b/lib/faq.ts
@@ -1,7 +1,7 @@
 export const FAQ_ITEMS = [
   {
     q: "How is it 90% cheaper?",
-    a: "Legacy CDNs provision for peak traffic and amortise that cost across long contracts, so a popular release gets expensive fast. deCDN is demand-shaped: supply forms around traffic, nodes cache what's hot, and bandwidth gets reused across many pulls. Cost per gigabyte collapses as regional demand concentrates — the opposite of how fixed-provisioning CDNs behave. Target price today: ~$0.01/GB, one cent, per actual gigabyte delivered.",
+    a: "Traditional CDNs provision for peak traffic and amortise that cost across long contracts, so a popular release gets expensive fast. deCDN is demand-shaped: supply forms around traffic, nodes cache what's hot, and bandwidth gets reused across many pulls. Cost per gigabyte collapses as regional demand concentrates — the opposite of how fixed-provisioning CDNs behave. Target price today: ~$0.01/GB, one cent, per actual gigabyte delivered.",
   },
   {
     q: "How is byte-level integrity enforced?",


### PR DESCRIPTION
## Summary

Renames the incumbent option from "legacy CDN" to "traditional CDN" across the site. "Legacy" reads as pejorative/obsolescence; "traditional" is a neutral-but-clear contrast against deCDN's peer-to-peer model.

## Changes

- **`components/site/Compare.tsx`** — Compare section header timestamp and the "traditional cdn" column label; all six `ComparisonRow` call sites updated to the renamed prop.
- **`components/ui/ComparisonRow.tsx`** — renamed the `legacy` prop → `traditional` (destructure, type, JSX) so the code identifier matches the copy.
- **`app/layout.tsx`** — metadata `DESCRIPTION`: "legacy networks" → "traditional networks" (ships to production SEO/OG output).
- **`lib/faq.ts`** — FAQ answer: "Legacy CDNs" → "Traditional CDNs".
- **`content/blog/01-why-now.mdx`** — blog prose: "Legacy CDN list pricing" → "Traditional CDN list pricing".

## Verification

- `pnpm lint` — clean
- `pnpm build` — static export succeeded
- `pnpm test` — 95/95 passed
- `grep -rni legacy` over `components/ app/ lib/ content/` — no matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)