### PR TITLE
feat(contact): rewrite section around actual contact channels

### DIFF
--- a/components/site/Contact.tsx
+++ b/components/site/Contact.tsx
@@ -1,4 +1,4 @@
-import { links } from "@/lib/links";
+import { EMAIL, links } from "@/lib/links";
 import { Frame } from "@/components/ui/Frame";
 import { SectionHeader } from "@/components/ui/SectionHeader";
 import { FleetStatus } from "@/components/site/FleetStatus";
@@ -54,7 +54,7 @@ export function Contact() {
               className="underline-brutal text-lead font-semibold tracking-[0.02em]"
               href={links.contact}
             >
-              info@decdn.org
+              {EMAIL}
               <span className="arrow" aria-hidden>
                 →
               </span>
@@ -76,7 +76,7 @@ export function Contact() {
               target="_blank"
               rel="noopener noreferrer"
             >
-              x
+              X (Twitter)
               <span className="arrow" aria-hidden>
                 →
               </span>

--- a/components/site/Contact.tsx
+++ b/components/site/Contact.tsx
@@ -35,13 +35,14 @@ export function Contact() {
             }}
           />
 
-          {/* prettier-ignore */}
           <p
             data-reveal
             style={{ "--reveal-delay": "120ms" }}
             className="max-w-[64ch] text-body leading-[1.7]"
           >
-            <span className="text-whisper">deCDN</span>{" "}is a peer-to-peer delivery layer for large files — software releases, datasets, media libraries, ai models, anything meant to be pulled a million times and that shouldn&apos;t depend on one bucket. the code is open. the network is open. the price is posted.
+            the network is open. so is our inbox. write us with questions,
+            partnerships, or anything you&apos;d run on a fleet of idle
+            machines. we read everything.
           </p>
 
           <div
@@ -51,29 +52,31 @@ export function Contact() {
           >
             <a
               className="underline-brutal text-lead font-semibold tracking-[0.02em]"
-              href={links.litepaper}
+              href={links.contact}
+            >
+              info@decdn.org
+              <span className="arrow" aria-hidden>
+                →
+              </span>
+            </a>
+            <a
+              className="underline-brutal text-lead font-semibold tracking-[0.02em]"
+              href={links.linkedin}
               target="_blank"
               rel="noopener noreferrer"
             >
-              read the litepaper
+              linkedin
               <span className="arrow" aria-hidden>
                 →
               </span>
             </a>
             <a
               className="underline-brutal text-lead font-semibold tracking-[0.02em]"
-              href={links.docs}
+              href={links.x}
+              target="_blank"
+              rel="noopener noreferrer"
             >
-              read the docs
-              <span className="arrow" aria-hidden>
-                →
-              </span>
-            </a>
-            <a
-              className="underline-brutal text-lead font-semibold tracking-[0.02em]"
-              href={links.github}
-            >
-              source on github
+              x
               <span className="arrow" aria-hidden>
                 →
               </span>

--- a/lib/links.ts
+++ b/lib/links.ts
@@ -1,3 +1,5 @@
+export const EMAIL = "info@decdn.org";
+
 export const links = {
   site: "https://decdn.org",
   github: "https://github.com/decdn",
@@ -7,7 +9,7 @@ export const links = {
   presskit: "/presskit/decdn-presskit.zip",
   docs: "https://docs.decdn.org/overview/introduction",
   blog: "/blog/",
-  contact: "mailto:info@decdn.org",
+  contact: `mailto:${EMAIL}`,
 } as const;
 
 // Trailing-slash base: lets callers concat `${SITE_URL}icon.svg` and


### PR DESCRIPTION
## Summary
- Rewrites the Contact section copy from a brand re-pitch to a contact-focused invitation that reuses the site's "open" motif.
- Drops the litepaper/docs/github links (already reachable from Hero, header, and mobile menu) and replaces them with the channels people actually expect on a contact section: `info@decdn.org`, linkedin, x — all wired to the existing `links` constants in `lib/links.ts`.
- `links.contact` was defined but unused before this change.

## Test plan
- [ ] `pnpm dev` and visit `/#contact` — confirm the new copy renders, the three links are present, the email opens a mail client, and linkedin/x open in new tabs.
- [ ] Verify the litepaper, docs, and github CTAs are still reachable from the Hero, the header (Chrome), and the mobile menu.
- [ ] `pnpm lint` and `pnpm format:check` pass.