### PR TITLE
docs(slashing): drop stale "corrupted delivery" slashable offense

### DIFF
--- a/docs/overview/how-it-works.mdx
+++ b/docs/overview/how-it-works.mdx
@@ -58,7 +58,7 @@ If pull-through is disabled in the node's config, the node returns a redirect po
 
 - **Hash verification.** Clients verify every chunk against the known blob hash. A bad byte voids payment.
 - **On-chain evidence.** Protocol messages are signed in a form that can be verified on-chain as evidence of phantom announcements, rate manipulation, or blacklist violations ([slashing](/protocol/slashing)).
-- **Challenge-response.** Submit evidence; the counterparty has a window to submit counter-evidence. The on-chain judge adjudicates after the window.
+- **Synchronous adjudication.** The on-chain judge verifies submitted evidence and slashes on the spot, with no counter-evidence window.
 - **Reputation.** A 0.0–1.0 score combining direct experience and signed gossip from staked nodes ([reputation](/protocol/reputation)).
 - **Content blacklist.** Governance-managed on-chain hash blacklist. Serving a blacklisted hash after the compliance window is slashable ([takedown](/protocol/takedown)).
 

--- a/docs/overview/how-it-works.mdx
+++ b/docs/overview/how-it-works.mdx
@@ -57,7 +57,7 @@ If pull-through is disabled in the node's config, the node returns a redirect po
 ## What keeps the network honest
 
 - **Hash verification.** Clients verify every chunk against the known blob hash. A bad byte voids payment.
-- **On-chain evidence.** Protocol messages are signed in a form that can be verified on-chain as evidence of corrupted delivery, phantom announcements, rate manipulation, or blacklist violations ([slashing](/protocol/slashing)).
+- **On-chain evidence.** Protocol messages are signed in a form that can be verified on-chain as evidence of phantom announcements, rate manipulation, or blacklist violations ([slashing](/protocol/slashing)).
 - **Challenge-response.** Submit evidence; the counterparty has a window to submit counter-evidence. The on-chain judge adjudicates after the window.
 - **Reputation.** A 0.0–1.0 score combining direct experience and signed gossip from staked nodes ([reputation](/protocol/reputation)).
 - **Content blacklist.** Governance-managed on-chain hash blacklist. Serving a blacklisted hash after the compliance window is slashable ([takedown](/protocol/takedown)).

--- a/docs/protocol/content-addressing.mdx
+++ b/docs/protocol/content-addressing.mdx
@@ -16,8 +16,6 @@ Every blob is identified by its **BLAKE3 hash**. Clients and nodes verify receiv
 
 Blobs are transmitted in chunks, each accompanied by the sibling hashes needed to prove inclusion in the root hash the client expects. The client accepts bytes only after verification, so a malicious node cannot insert a single corrupt byte and still earn — the client rejects the stream before paying for that chunk.
 
-The on-chain corruption evidence path uses the same chunking ([slashing](/protocol/slashing)).
-
 ## Hash-to-object-key mapping
 
 Origin backends speak their own namespace: S3 objects are addressed by key, NFS by path, local disk by filename. Blobs are addressed by BLAKE3 hash. The mapping lives in a **content catalog** — a small database (PostgreSQL or SQLite) maintained by the operator:

--- a/docs/protocol/slashing.mdx
+++ b/docs/protocol/slashing.mdx
@@ -1,29 +1,17 @@
 ---
 title: Slashing & on-chain verification
-description: Four slashable offenses with on-chain evidence paths and challenge-based adjudication.
+description: Three slashable offenses with on-chain evidence paths and challenge-based adjudication.
 ---
 
 ## Decision
 
-Four slashable offenses with concrete on-chain evidence paths:
+Three slashable offenses with concrete on-chain evidence paths:
 
-1. **Corrupted delivery** — bytes that do not hash to the requested blob.
-2. **Phantom announcement** — claimed availability, failed to deliver.
-3. **Rate manipulation** — charged a rate different from the advertised rate.
-4. **Blacklist violation** — served a blacklisted hash after the compliance window.
+1. **Phantom announcement** — claimed availability, failed to deliver.
+2. **Rate manipulation** — charged a rate different from the advertised rate.
+3. **Blacklist violation** — served a blacklisted hash after the compliance window.
 
-A unified on-chain judge adjudicates all four and triggers stake slashing on resolution.
-
-## Immediate vs. deferred
-
-| Offense              | Counter window   | Rationale                                                                     |
-| -------------------- | ---------------- | ----------------------------------------------------------------------------- |
-| Phantom announcement | None — immediate | Probe response + stream failure is self-contained evidence                    |
-| Blacklist violation  | None — immediate | Serving a blacklisted hash is self-evident                                    |
-| Corrupted delivery   | Counter window   | The accused can submit a counter-receipt                                      |
-| Rate manipulation    | Counter window   | The accused can submit the legitimate rate change between disputed timestamps |
-
-For high-value disputes the corruption evidence path upgrades to an interactive Merkle proof matching the hash-tree leaf size used for verified streaming ([content addressing](/protocol/content-addressing)).
+A unified on-chain judge adjudicates all three and triggers stake slashing on resolution.
 
 ## Evidence staleness
 

--- a/docs/protocol/slashing.mdx
+++ b/docs/protocol/slashing.mdx
@@ -1,6 +1,6 @@
 ---
 title: Slashing & on-chain verification
-description: Three slashable offenses with on-chain evidence paths and challenge-based adjudication.
+description: Three slashable offenses with on-chain evidence paths and synchronous on-chain adjudication.
 ---
 
 ## Decision
@@ -11,7 +11,7 @@ Three slashable offenses with concrete on-chain evidence paths:
 2. **Rate manipulation** — charged a rate different from the advertised rate.
 3. **Blacklist violation** — served a blacklisted hash after the compliance window.
 
-A unified on-chain judge adjudicates all three and triggers stake slashing on resolution.
+A unified on-chain judge adjudicates all three synchronously and triggers stake slashing immediately upon verification.
 
 ## Evidence staleness
 


### PR DESCRIPTION
## Summary

- Per [ADR 014](https://github.com/decdn/decdn/blob/main/adr/014-on-chain-verification.md), content corruption is absorbed at the wire (client-side BLAKE3 + voucher gating, [ADR 003](https://github.com/decdn/decdn/blob/main/adr/003-payments.md)), not on-chain. The on-chain slashable offenses are **phantom announcement**, **rate manipulation**, and **blacklist violation** — three, not four.
- Also drop the "Immediate vs. deferred" table and Merkle-escalation paragraph in `slashing.mdx`. Per [ADR 014](https://github.com/decdn/decdn/blob/main/adr/014-on-chain-verification.md) and [ADR 028](https://github.com/decdn/decdn/blob/main/adr/028-slashing-appeals.md), all three offenses resolve synchronously at submit time with no counter-evidence window.

## Files

- `docs/protocol/slashing.mdx` — 4 → 3 offenses, drop stale table + Merkle paragraph
- `docs/protocol/content-addressing.mdx` — drop dangling "on-chain corruption evidence path" sentence
- `docs/overview/how-it-works.mdx` — drop "corrupted delivery" from on-chain evidence list

## Test plan

- [ ] Mintlify preview renders cleanly (no broken links / table syntax)
- [ ] No remaining references to a fourth "corrupted delivery" slashable offense in `docs/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)