### PR TITLE
docs(overview): add design decisions page

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -28,6 +28,7 @@
               "overview/architecture",
               "overview/participants",
               "overview/how-it-works",
+              "overview/design-decisions",
               "overview/glossary"
             ]
           }

--- a/docs/overview/design-decisions.mdx
+++ b/docs/overview/design-decisions.mdx
@@ -1,0 +1,35 @@
+---
+title: Design decisions
+description: Accepted architecture decision records that define the protocol.
+---
+
+The protocol is shaped by a set of accepted ADRs. The table below names each one. Full text is not yet public; numbering gaps reflect superseded or withdrawn proposals.
+
+| ADR | Decision                       |
+| --- | ------------------------------ |
+| 000 | Language stack                 |
+| 001 | Network topology               |
+| 002 | Content addressing             |
+| 003 | Payment model                  |
+| 005 | Wire protocol                  |
+| 008 | Reputation system              |
+| 009 | Governance model               |
+| 011 | Content takedown               |
+| 012 | Client architecture            |
+| 013 | Schema evolution               |
+| 014 | On-chain slashing verification |
+| 015 | QUIC 0-RTT                     |
+| 016 | Smart contract interaction     |
+| 017 | Privacy                        |
+| 018 | Liquidity strategy             |
+| 019 | Node onboarding                |
+| 022 | Content discovery              |
+| 024 | Account abstraction            |
+| 026 | Tokenomics                     |
+| 028 | Slashing appeals               |
+| 030 | Region self-attestation        |
+| 031 | Content blacklist appeals      |
+| 032 | Safety reserve appeals         |
+| 033 | Safety insurance reserve       |
+| 034 | Gauge boost and voting escrow  |
+| 035 | Delegator pool                 |


### PR DESCRIPTION
## Summary
- New Overview page listing the 26 accepted ADRs by ID and title — surfaces architectural depth on docs.decdn.org so the marketing CTA can deep-link to substance instead of generic docs.
- Renames the compliance-flavored cluster in the table only (e.g. `ContentBlacklist appeal-contract surface` → `Content blacklist appeals`) so casual readers don't misread Solidity contract jargon as legal proceedings. ADR source filenames in `decdn/adr/` are untouched.
- Numbering gaps (004, 006, 007, 010, …) are kept as honest history of superseded or withdrawn proposals.

Nav order under Overview: `introduction → architecture → participants → how-it-works → design-decisions → glossary`.

## Test plan
- [ ] `mintlify dev` from `docs/`, confirm the page renders at `/overview/design-decisions`
- [ ] Verify nav order in the sidebar
- [ ] Check table renders all 26 rows with the expected titles
- [ ] Confirm no claims about ADR content (titles only, no substance leak)

🤖 Generated with [Claude Code](https://claude.com/claude-code)