### PR TITLE
feat(contact): add channel icons to email, linkedin, and x links

### DIFF
--- a/components/site/Contact.tsx
+++ b/components/site/Contact.tsx
@@ -11,8 +11,7 @@ const wordmarkH = "clamp(4.75rem, 14vw, 11.5rem)";
 // shrink-0 keeps the box from compressing in the inline-flex link. The
 // envelope is an original geometric glyph; the X and LinkedIn glyphs are from
 // Simple Icons (CC0 / public domain) — the marks are trademarks of their
-// owners, shown nominatively as links to our own profiles. LinkedIn is the
-// bare "in" mark, no badge.
+// owners, shown nominatively as links to our own profiles.
 const iconClass = "size-[1.05em] shrink-0";
 
 function MailIcon() {
@@ -39,7 +38,7 @@ function LinkedInIcon() {
       aria-hidden
       className={iconClass}
     >
-      <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452z" />
+      <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
     </svg>
   );
 }

--- a/components/site/Contact.tsx
+++ b/components/site/Contact.tsx
@@ -8,8 +8,10 @@ const wordmarkH = "clamp(4.75rem, 14vw, 11.5rem)";
 // Solid monochrome glyphs leading each contact link. Decorative — every link
 // carries its own visible text label — so each <svg> is aria-hidden. Sized to
 // the text-lead cap height; shrink-0 keeps them from squishing in the
-// inline-flex link. Mail is Material Design's solid envelope; LinkedIn and X
-// are the Simple Icons brand marks.
+// inline-flex link. The envelope is an original geometric glyph; the X and
+// LinkedIn glyphs are derived from Simple Icons (CC0 / public domain) — the
+// marks are trademarks of their owners, shown nominatively as links to our
+// own profiles. LinkedIn is the bare "in" mark, no badge.
 const iconClass = "size-[1.05em] shrink-0";
 
 function MailIcon() {
@@ -20,7 +22,10 @@ function MailIcon() {
       aria-hidden
       className={iconClass}
     >
-      <path d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z" />
+      <path
+        fillRule="evenodd"
+        d="M2.5 5H21.5V19H2.5ZM3.6 6.2 12 12.6 20.4 6.2 20.4 8 12 14.4 3.6 8Z"
+      />
     </svg>
   );
 }
@@ -33,7 +38,7 @@ function LinkedInIcon() {
       aria-hidden
       className={iconClass}
     >
-      <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+      <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452z" />
     </svg>
   );
 }

--- a/components/site/Contact.tsx
+++ b/components/site/Contact.tsx
@@ -6,12 +6,13 @@ import { FleetStatus } from "@/components/site/FleetStatus";
 const wordmarkH = "clamp(4.75rem, 14vw, 11.5rem)";
 
 // Solid monochrome glyphs leading each contact link. Decorative — every link
-// carries its own visible text label — so each <svg> is aria-hidden. Sized to
-// the text-lead cap height; shrink-0 keeps them from squishing in the
-// inline-flex link. The envelope is an original geometric glyph; the X and
-// LinkedIn glyphs are derived from Simple Icons (CC0 / public domain) — the
-// marks are trademarks of their owners, shown nominatively as links to our
-// own profiles. LinkedIn is the bare "in" mark, no badge.
+// carries its own visible text label — so each <svg> is aria-hidden. iconClass
+// sizes them in em (1.05×), so each glyph scales with its link's font-size;
+// shrink-0 keeps the box from compressing in the inline-flex link. The
+// envelope is an original geometric glyph; the X and LinkedIn glyphs are from
+// Simple Icons (CC0 / public domain) — the marks are trademarks of their
+// owners, shown nominatively as links to our own profiles. LinkedIn is the
+// bare "in" mark, no badge.
 const iconClass = "size-[1.05em] shrink-0";
 
 function MailIcon() {

--- a/components/site/Contact.tsx
+++ b/components/site/Contact.tsx
@@ -5,6 +5,52 @@ import { FleetStatus } from "@/components/site/FleetStatus";
 
 const wordmarkH = "clamp(4.75rem, 14vw, 11.5rem)";
 
+// Solid monochrome glyphs leading each contact link. Decorative — every link
+// carries its own visible text label — so each <svg> is aria-hidden. Sized to
+// the text-lead cap height; shrink-0 keeps them from squishing in the
+// inline-flex link. Mail is Material Design's solid envelope; LinkedIn and X
+// are the Simple Icons brand marks.
+const iconClass = "size-[1.05em] shrink-0";
+
+function MailIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden
+      className={iconClass}
+    >
+      <path d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z" />
+    </svg>
+  );
+}
+
+function LinkedInIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden
+      className={iconClass}
+    >
+      <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+    </svg>
+  );
+}
+
+function XIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden
+      className={iconClass}
+    >
+      <path d="M18.901 1.153h3.68l-8.04 9.19L24 22.846h-7.406l-5.8-7.584-6.638 7.584H.474l8.6-9.83L0 1.154h7.594l5.243 6.932ZM17.61 20.644h2.039L6.486 3.24H4.298Z" />
+    </svg>
+  );
+}
+
 export function Contact() {
   return (
     <Frame id="contact" tone="paper" className="overflow-hidden" fill={false}>
@@ -54,6 +100,7 @@ export function Contact() {
               className="underline-brutal text-lead font-semibold tracking-[0.02em]"
               href={links.contact}
             >
+              <MailIcon />
               {EMAIL}
               <span className="arrow" aria-hidden>
                 →
@@ -65,6 +112,7 @@ export function Contact() {
               target="_blank"
               rel="noopener noreferrer"
             >
+              <LinkedInIcon />
               linkedin
               <span className="arrow" aria-hidden>
                 →
@@ -76,7 +124,7 @@ export function Contact() {
               target="_blank"
               rel="noopener noreferrer"
             >
-              x (twitter)
+              <XIcon />x (twitter)
               <span className="arrow" aria-hidden>
                 →
               </span>


### PR DESCRIPTION
## Summary

Adds a leading glyph to each of the three contact links in the Contact section so the channels are scannable at a glance, not just by reading the label.

- Each link reads: glyph, then label, then the existing animated `→` arrow — the arrow and its hover slide are kept (additive change, confirmed with design intent).
- Glyphs are inline SVG, no icon library — `package.json` stays lean, consistent with the codebase having no icon dependency by design. The envelope is an original geometric glyph; the X and LinkedIn glyphs are from Simple Icons (CC0 / public domain). The repo carries no third-party-licensed icon code.
- Glyphs are `aria-hidden` (each link already carries a visible text label), sized in `em` (1.05×) so they scale with each link's font-size, and inherit `currentColor`. No CSS changes were needed: `a.underline-brutal` is already `inline-flex` with a gap, so a glyph dropped in as the first child is spaced and aligned automatically.

Scope is limited to `components/site/Contact.tsx`; the "x (twitter)" label, Footer, and Chrome are untouched.

## Verification

- `pnpm lint` — clean
- `pnpm format:check` — clean
- `pnpm build` — static export succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)