### PR TITLE
chore: theme token cleanup + chrome-active helper

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -6,15 +6,15 @@
   --whisper: #0f9d6a;
   /* Intentionally 0: anchor jumps land flush at viewport top (under
      the fixed nav). Section headers don't get clipped because every
-     Frame's --frame-pad-y floor (5rem = 80px) sits comfortably above
-     the current fixed-nav height (py-5 + 30px wordmark ≈ 70px),
+     Frame's --spacing-frame-pad-y floor (5rem = 80px) sits comfortably
+     above the current fixed-nav height (py-5 + 30px wordmark ≈ 70px),
      leaving ~10px of breathing room below the nav. If the nav grows
      past 5rem, set --nav-h to the measured nav height — Frame already
      applies scroll-mt-[var(--nav-h)] on every section, so anchor
      offsets pick it up automatically. (Bumping the 5rem floor on
-     --frame-pad-y only helps below ~889px — above that the clamp's
-     9vw term already exceeds 5rem, so a bigger floor does nothing on
-     desktop.) */
+     --spacing-frame-pad-y only helps below ~889px — above that the
+     clamp's 9vw term already exceeds 5rem, so a bigger floor does
+     nothing on desktop.) */
   --nav-h: 0;
 }
 
@@ -23,15 +23,15 @@
   --color-paper: var(--paper);
   --color-whisper: var(--whisper);
 
-  /* Shared content rail: every Frame centers within --frame-max. */
-  --frame-max: 1280px;
-  --frame-gutter: clamp(1.5rem, 4vw, 4rem);
-  --frame-pad-y: clamp(
+  /* Shared content rail: every Frame centers within --container-frame. */
+  --container-frame: 1280px;
+  --spacing-frame-gutter: clamp(1.5rem, 4vw, 4rem);
+  --spacing-frame-pad-y: clamp(
     5rem,
     9vw,
     7rem
   ); /* floor coupled to nav height — see --nav-h note above */
-  --frame-min-h-cap: 54rem;
+  --spacing-frame-min-h: min(100svh, 54rem);
 
   /* Type scale: micro and CTA are fixed; body and headlines scale with viewport.
      Named under Tailwind v4's --text-* namespace so `text-body`, `text-h1`, …
@@ -1008,7 +1008,7 @@ a.underline-brutal:hover .arrow {
 .mm-toggle {
   position: fixed;
   top: 24px;
-  right: var(--frame-gutter);
+  right: var(--spacing-frame-gutter);
   z-index: 65;
   width: 22px;
   height: 22px;

--- a/app/globals.css
+++ b/app/globals.css
@@ -22,7 +22,6 @@
   --color-ink: var(--ink);
   --color-paper: var(--paper);
   --color-whisper: var(--whisper);
-  --font-sans: var(--font-geist-sans);
 
   /* Shared content rail: every Frame centers within --frame-max. */
   --frame-max: 1280px;

--- a/components/site/Chrome.tsx
+++ b/components/site/Chrome.tsx
@@ -170,11 +170,6 @@ export function Chrome() {
     return () => window.removeEventListener("scroll", onScroll);
   }, [pathname]);
 
-  // Guard against a stale `active` landing in `DARK_SECTIONS` and painting
-  // `text-paper` over a paper-toned page: off-home the IO observes nothing,
-  // and on the first render after a client nav `active` still holds the
-  // previous route's last value until the [pathname] effects re-sync.
-  // `scrolled` doubles as a proxy for "past the intro hero".
   const effectiveActive = resolveActiveSection(
     pathname,
     scrolled,

--- a/components/site/Chrome.tsx
+++ b/components/site/Chrome.tsx
@@ -6,6 +6,7 @@ import { usePathname } from "next/navigation";
 import { links } from "@/lib/links";
 import { homeHashSectionId, shouldInterceptNavClick } from "@/lib/scroll";
 import { MobileMenu } from "@/components/site/MobileMenu";
+import { resolveActiveSection } from "@/components/site/chrome-active";
 
 const SECTION_IDS = ["intro", "compare", "method", "faq", "contact"] as const;
 // Hash anchors are written `/#section`. Required because this nav also
@@ -174,7 +175,12 @@ export function Chrome() {
   // and on the first render after a client nav `active` still holds the
   // previous route's last value until the [pathname] effects re-sync.
   // `scrolled` doubles as a proxy for "past the intro hero".
-  const effectiveActive = pathname === "/" && scrolled ? active : "intro";
+  const effectiveActive = resolveActiveSection(
+    pathname,
+    scrolled,
+    active,
+    "intro",
+  );
   const onDark = DARK_SECTIONS.has(effectiveActive);
   // The toggle is portalled to <body> (see MobileMenu.tsx) and lives
   // on top of the paper panel while the drawer is open — force it to

--- a/components/site/Chrome.tsx
+++ b/components/site/Chrome.tsx
@@ -188,11 +188,11 @@ export function Chrome() {
       data-scrolled={scrolled ? "true" : undefined}
       data-tone={onDark ? "ink" : "paper"}
       data-mobile-open={mobileOpen ? "true" : undefined}
-      className={`chrome-nav fixed inset-x-0 top-0 z-50 px-[var(--frame-gutter)] py-5 ${
+      className={`chrome-nav fixed inset-x-0 top-0 z-50 px-frame-gutter py-5 ${
         onDark ? "text-paper" : "text-ink"
       }`}
     >
-      <div className="mx-auto grid w-full max-w-[var(--frame-max)] grid-cols-[1fr_auto_1fr] items-center gap-4">
+      <div className="mx-auto grid w-full max-w-frame grid-cols-[1fr_auto_1fr] items-center gap-4">
         <Link
           href="/#intro"
           onClick={handleNavClick}

--- a/components/site/Footer.tsx
+++ b/components/site/Footer.tsx
@@ -2,8 +2,8 @@ import { links } from "@/lib/links";
 
 export function Footer() {
   return (
-    <footer className="bg-paper px-[var(--frame-gutter)] pb-10 text-ink">
-      <div className="@container mx-auto flex max-w-[var(--frame-max)] flex-col gap-3">
+    <footer className="bg-paper px-frame-gutter pb-10 text-ink">
+      <div className="@container mx-auto flex max-w-frame flex-col gap-3">
         <span aria-hidden className="rule opacity-40" />
         <div className="grid grid-cols-1 gap-2 text-micro tracking-[0.2em] uppercase opacity-80 @md:grid-cols-3 @md:items-center">
           <span>© decdn labs · open source</span>

--- a/components/site/chrome-active.test.ts
+++ b/components/site/chrome-active.test.ts
@@ -38,6 +38,13 @@ describe("resolveActiveSection", () => {
       observed: "faq",
       expected: "intro",
     },
+    {
+      name: "home with query string falls back (exact match)",
+      pathname: "/?utm=x",
+      scrolled: true,
+      observed: "compare",
+      expected: "intro",
+    },
   ] as const)("$name", ({ pathname, scrolled, observed, expected }) => {
     expect(resolveActiveSection(pathname, scrolled, observed, "intro")).toBe(
       expected,

--- a/components/site/chrome-active.test.ts
+++ b/components/site/chrome-active.test.ts
@@ -4,7 +4,7 @@ import { resolveActiveSection } from "./chrome-active";
 describe("resolveActiveSection", () => {
   it.each([
     {
-      name: "off-home + scrolled falls back (the #112 bug)",
+      name: "off-home + scrolled falls back",
       pathname: "/blog/foo/",
       scrolled: true,
       observed: "compare",

--- a/components/site/chrome-active.test.ts
+++ b/components/site/chrome-active.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { resolveActiveSection } from "./chrome-active";
+
+describe("resolveActiveSection", () => {
+  it.each([
+    {
+      name: "off-home + scrolled falls back (the #112 bug)",
+      pathname: "/blog/foo/",
+      scrolled: true,
+      observed: "compare",
+      expected: "intro",
+    },
+    {
+      name: "home but not yet scrolled falls back (back-nav flash guard)",
+      pathname: "/",
+      scrolled: false,
+      observed: "compare",
+      expected: "intro",
+    },
+    {
+      name: "home + scrolled returns the observed dark section",
+      pathname: "/",
+      scrolled: true,
+      observed: "compare",
+      expected: "compare",
+    },
+    {
+      name: "home + scrolled passes other DARK_SECTIONS members through",
+      pathname: "/",
+      scrolled: true,
+      observed: "faq",
+      expected: "faq",
+    },
+    {
+      name: "off-home dominates regardless of scrolled state",
+      pathname: "/blog/",
+      scrolled: false,
+      observed: "faq",
+      expected: "intro",
+    },
+  ] as const)("$name", ({ pathname, scrolled, observed, expected }) => {
+    expect(resolveActiveSection(pathname, scrolled, observed, "intro")).toBe(
+      expected,
+    );
+  });
+});

--- a/components/site/chrome-active.ts
+++ b/components/site/chrome-active.ts
@@ -1,4 +1,10 @@
-export function resolveActiveSection<T>(
+// Why both `pathname === "/"` and `scrolled` must hold for `observed` to win:
+// - Off-home, the caller's section observer holds stale values from the
+//   previous home-route render — off-home reads must dominate.
+// - On home, `scrolled` doubles as a "past the intro hero" proxy that
+//   suppresses the brief window after a client-side back-nav resets scroll
+//   to top while the observer's last value is still in flight.
+export function resolveActiveSection<T extends string>(
   pathname: string,
   scrolled: boolean,
   observed: T,

--- a/components/site/chrome-active.ts
+++ b/components/site/chrome-active.ts
@@ -1,10 +1,11 @@
-// Why both `pathname === "/"` and `scrolled` must hold for `observed` to win:
-// - Off-home, the caller's section observer holds stale values from the
-//   previous home-route render — off-home reads must dominate.
-// - On home, `scrolled` doubles as a "past the intro hero" proxy that
-//   suppresses the brief window after a client-side back-nav resets scroll
-//   to top while the observer's last value is still in flight.
-export function resolveActiveSection<T extends string>(
+// Both `pathname === "/"` and `scrolled` must hold for `observed` to win.
+// Off-home, the caller's observer never gets built but `active` still
+// holds its last home-route value — the home check stops that stale value
+// painting. On home, `active` is briefly stale between the route-change
+// render and the new observer's first callback; `scrolled` (scrollY > 8)
+// stands in for "observer has had a moment to fire". Caveat: back-nav
+// with restored scroll skips this — a brief stale-tone flash is possible.
+export function resolveActiveSection<T>(
   pathname: string,
   scrolled: boolean,
   observed: T,

--- a/components/site/chrome-active.ts
+++ b/components/site/chrome-active.ts
@@ -1,0 +1,8 @@
+export function resolveActiveSection<T>(
+  pathname: string,
+  scrolled: boolean,
+  observed: T,
+  fallback: T,
+): T {
+  return pathname === "/" && scrolled ? observed : fallback;
+}

--- a/components/ui/Frame.tsx
+++ b/components/ui/Frame.tsx
@@ -29,8 +29,8 @@ export function Frame({
   children,
 }: FrameProps) {
   const sectionClass = [
-    "relative flex flex-col scroll-mt-[var(--nav-h)] px-[var(--frame-gutter)] py-[var(--frame-pad-y)]",
-    fill && "min-h-[min(100svh,var(--frame-min-h-cap))]",
+    "relative flex flex-col scroll-mt-[var(--nav-h)] px-frame-gutter py-frame-pad-y",
+    fill && "min-h-frame-min-h",
     TONE_CLASS[tone],
     className,
   ]
@@ -38,7 +38,7 @@ export function Frame({
     .join(" ");
   return (
     <section id={id} aria-labelledby={`${id}-h`} className={sectionClass}>
-      <div className="@container relative z-10 mx-auto flex w-full max-w-[var(--frame-max)] flex-1 flex-col">
+      <div className="@container relative z-10 mx-auto flex w-full max-w-frame flex-1 flex-col">
         {children}
       </div>
     </section>


### PR DESCRIPTION
## Summary

- Drop the unreferenced `--font-sans` token from `@theme inline` — `html, body` already applies the typeface directly and no component uses the `font-sans` utility (closes #105).
- Promote the remaining `--frame-*` layout tokens to Tailwind v4 namespaces (`--spacing-frame-*` / `--container-frame`), so `px-frame-gutter` / `py-frame-pad-y` / `max-w-frame` / `min-h-frame-min-h` utilities replace the `[var(--frame-*)]` arbitrary-value classes left over from #101. Finishes the Approach-A migration started in #78 (closes #102).
- Extract the home-route-gated nav-tone ternary in `Chrome.tsx` into a pure `resolveActiveSection` helper (rationale doc co-located with the function) and add 6 unit tests covering both regression guards, all four AND-gate quadrants, and the exact-match boundary — no jsdom needed (closes #117).

#115 was reviewed in parallel and intentionally deferred (audit comment posted on the issue); the helper extracted here is where its routing-aware fix will live.

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm test` — 101 pass, including the 6 `resolveActiveSection` cases
- [x] `pnpm build` — static export clean; built CSS contains `.px-frame-gutter` / `.py-frame-pad-y` / `.max-w-frame` / `.min-h-frame-min-h` and zero `var(--frame-*)` refs
- [ ] `pnpm dev` smoke: gutter / max-width rail / section min-height visually unchanged on `/`, `/blog/`, and a post
- [ ] Nav tone: scroll past intro on `/` → `text-paper`; back-nav `/blog/` → `/` paints `text-ink` until first scroll; `/blog/foo/` stays `text-ink` regardless of scroll
- [ ] Mobile drawer (<768px): close `×` sits at the same gutter offset

🤖 Generated with [Claude Code](https://claude.com/claude-code)