### PR TITLE
chore: update X profile link to @decdn_

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -65,7 +65,7 @@
   "footer": {
     "socials": {
       "github": "https://github.com/decdn",
-      "x": "https://x.com/decdnorg"
+      "x": "https://x.com/decdn_"
     },
     "links": [
       {

--- a/lib/links.ts
+++ b/lib/links.ts
@@ -3,7 +3,7 @@ export const EMAIL = "info@decdn.org";
 export const links = {
   site: "https://decdn.org",
   github: "https://github.com/decdn",
-  x: "https://x.com/deCDNorg",
+  x: "https://x.com/decdn_",
   linkedin: "https://www.linkedin.com/company/decdn",
   litepaper: "/decdn_litepaper.pdf",
   presskit: "/presskit/decdn-presskit.zip",


### PR DESCRIPTION
## Summary

Replaces the X (Twitter) profile links with the `@decdn_` handle.

- `lib/links.ts` — `links.x` now points to `https://x.com/decdn_`. The `X_HANDLE` export (used for the `twitter:site` / `twitter:creator` meta tags in `app/layout.tsx` and the Organization `sameAs` JSON-LD) is derived from this URL, so it automatically resolves to `@decdn_`.
- `docs/docs.json` — Mintlify footer social `x` link updated to match.

No other changes needed: the Contact section, layout metadata, and JSON-LD all read from `links.x` / `X_HANDLE`, so the single source of truth update propagates everywhere.

https://claude.ai/code/session_014cexbtJrbnWAGZ5RoHWPP6

---
_Generated by [Claude Code](https://claude.ai/code/session_014cexbtJrbnWAGZ5RoHWPP6)_