### PR TITLE
docs(blog): lowercase decdn wordmark in post 00 summary

### DIFF
--- a/content/blog/00-what-were-building.mdx
+++ b/content/blog/00-what-were-building.mdx
@@ -2,7 +2,7 @@
 title: "What We're Building"
 slug: what-were-building
 date: 2026-05-04
-summary: "What deCDN is, who it's for, and what the protocol composes — a plain-English introduction."
+summary: "What decdn is, who it's for, and what the protocol composes — a plain-English introduction."
 bucket: pillar
 tags: [protocol, architecture, overview]
 ---


### PR DESCRIPTION
## Summary

- Follow-up to #139. Post 00's `summary` frontmatter used the `deCDN` brand mark while its body — and every other post — uses the lowercase `decdn` wordmark. Aligns the summary to match.
- This is the same inconsistency Gemini flagged on #139 for post 03; post 00 was the lone remaining exception once #139 merged.

## Verification

- `pnpm test` → 95/95 passing

## Note

`main` auto-deploys. This is a one-word copy edit to an already-published post (`/blog/what-were-building`); merging just updates the summary/meta text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)