### PR TITLE
chore(compare): label deCDN column "decentralized" not "peer-to-peer"

### DIFF
--- a/components/site/Compare.tsx
+++ b/components/site/Compare.tsx
@@ -46,7 +46,7 @@ export function Compare() {
             </div>
             <div className="meta @xl:col-span-5">
               decdn
-              <span className="ml-2 opacity-60">/ peer-to-peer</span>
+              <span className="ml-2 opacity-60">/ decentralized</span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Updates the Compare section's deCDN column label from `decdn / peer-to-peer` to `decdn / decentralized`, parallel to the adjacent "traditional cdn" label.

## Test plan
- `pnpm dev` and view the Compare section — the deCDN column header reads "decdn / decentralized".

🤖 Generated with [Claude Code](https://claude.com/claude-code)