### PR TITLE
docs: sync design-decisions ADR index to canonical set

### DIFF
--- a/docs/overview/design-decisions.mdx
+++ b/docs/overview/design-decisions.mdx
@@ -29,7 +29,4 @@ The protocol is shaped by a set of accepted ADRs. The table below names each one
 | 028 | Slashing appeals               |
 | 030 | Region self-attestation        |
 | 031 | Content blacklist appeals      |
-| 032 | Safety reserve appeals         |
-| 033 | Safety insurance reserve       |
-| 034 | Gauge boost and voting escrow  |
-| 035 | Delegator pool                 |
+| 036 | Served-bytes voting weight     |


### PR DESCRIPTION
## Summary

Syncs the public `overview/design-decisions` ADR index table with the canonical ADR set in `decdn/decdn` (`adr/`), which had drifted.

- Removed retired ADRs **032–035** (Safety reserve appeals, Safety insurance reserve, Gauge boost and voting escrow, Delegator pool) — these were retired and moved to `adr/_history/`.
- Added **036 Served-bytes voting weight** — present in the repo but missing from the page.

Rows 000–031 are unchanged. The intro note ("numbering gaps reflect superseded or withdrawn proposals") already covers the resulting 032–035 gap, so no prose change was needed.

## Notes

Out of scope (left as-is): the page calls these "accepted ADRs," but most are internally `Draft`/`Proposed`. Exposing per-ADR status would be a separate, larger change.

## Test plan

- [x] `prettier --check` passes on the edited MDX
- [x] Table cross-checked against active `adr/*.md` files (000–031, 036)

🤖 Generated with [Claude Code](https://claude.com/claude-code)