### PR TITLE
docs: sync protocol docs to canonical decdn/decdn state

### DIFF
--- a/docs/overview/architecture.mdx
+++ b/docs/overview/architecture.mdx
@@ -52,7 +52,7 @@ See [Participants](/overview/participants) for a deeper breakdown per role.
 1. **Client bootstrap** — client generates a keypair, queries the on-chain registry, seeds a peer table, and subscribes to regional + global gossip topics.
 2. **Discovery** — client probes its known peers for a blob hash. On miss, any peer performs a DHT lookup to locate holders.
 3. **Selection** — returned candidates are scored by price, latency, and reputation; lowest cost wins.
-4. **Payment channel open** — client opens a payment channel in an allowlisted ERC-20 with the selected node on-chain ([payments](/protocol/payments)).
+4. **Payment channel open** — client opens a USDC payment channel with the selected node on-chain ([payments](/protocol/payments)).
 5. **Streaming + vouchers** — node streams to the client; client signs off-chain vouchers as bytes flow.
 6. **Cache-miss fan-out** — if the node doesn't have the blob, it pulls from another peer (paid). Every byte delivered in the network is paid.
 7. **Channel close** — either party initiates settlement on-chain, with a dispute window for stale closes.

--- a/docs/overview/design-decisions.mdx
+++ b/docs/overview/design-decisions.mdx
@@ -30,3 +30,4 @@ The protocol is shaped by a set of accepted ADRs. The table below names each one
 | 030 | Region self-attestation        |
 | 031 | Content blacklist appeals      |
 | 036 | Served-bytes voting weight     |
+| 037 | Regional proxy warming         |

--- a/docs/overview/glossary.mdx
+++ b/docs/overview/glossary.mdx
@@ -3,20 +3,21 @@ title: Glossary
 description: Core terms used across the deCDN protocol and this documentation.
 ---
 
-| Term                   | Definition                                                                                                                                              |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Blob**               | A content-addressed byte sequence. Every blob is identified by its hash; clients verify received bytes against the known hash.                          |
-| **Channel (payment)**  | On-chain escrow between client and node that backs off-chain vouchers. Opens with a deposit; settles with the latest voucher.                           |
-| **Client**             | A lightweight QUIC endpoint that streams content and pays per MB. No stake, no gossip publish.                                                          |
-| **DHT**                | Kademlia-subset content discovery. Nodes self-publish records when caching a blob.                                                                      |
-| **Gossip**             | Epidemic broadcast over topic channels for node metadata and rate updates.                                                                              |
-| **Hash sequence**      | An ordered collection of blob hashes (a directory or manifest equivalent).                                                                              |
-| **Node**               | A staked QUIC endpoint that caches and delivers blobs. Some are origin-backed; others are pure caches.                                                  |
-| **Origin-backed node** | A node configured with an S3-compatible store, NFS mount, or local disk — the canonical source for specific blobs. Never experiences a true cache miss. |
-| **Origin backend**     | The opaque storage behind an origin-backed node (S3, R2, B2, MinIO, NFS, local disk). Never exposed to the network.                                     |
-| **Peer mesh**          | The flat set of all staked nodes. Discovery via gossip; content location via DHT.                                                                       |
-| **Probe**              | Parallel latency + availability check that runs before any delivery commitment.                                                                         |
-| **Selection score**    | A combined ranking over advertised price, observed latency, and reputation. Lower is better.                                                            |
-| **Stake**              | TOKEN locked on-chain by a node to join the mesh. Returned on deregistration after an unbonding period.                                                 |
-| **TOKEN**              | The deCDN governance and staking token. Not used for payments.                                                                                          |
-| **Voucher**            | A signed off-chain payment message. The primary payment instrument between client and node.                                                             |
+| Term                   | Definition                                                                                                                                                                        |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Blob**               | A content-addressed byte sequence. Every blob is identified by its hash; clients verify received bytes against the known hash.                                                    |
+| **Channel (payment)**  | On-chain escrow between client and node that backs off-chain vouchers. Opens with a deposit; settles with the latest voucher.                                                     |
+| **Client**             | A lightweight QUIC endpoint that streams content and pays per MB. No stake, no gossip publish.                                                                                    |
+| **DHT**                | Kademlia-subset content discovery. Nodes self-publish records when caching a blob.                                                                                                |
+| **Gossip**             | Epidemic broadcast over topic channels for node metadata and rate updates.                                                                                                        |
+| **Hash sequence**      | An ordered collection of blob hashes (a directory or manifest equivalent).                                                                                                        |
+| **Node**               | A staked QUIC endpoint that caches and delivers blobs. Some are origin-backed; others are pure caches.                                                                            |
+| **Origin-backed node** | A node configured with an S3-compatible store, NFS mount, or local disk — the canonical source for specific blobs. Never experiences a true cache miss.                           |
+| **Origin backend**     | The opaque storage behind an origin-backed node (S3, R2, B2, MinIO, NFS, local disk). Never exposed to the network.                                                               |
+| **Peer mesh**          | The flat set of all staked nodes. Discovery via gossip; content location via DHT.                                                                                                 |
+| **Probe**              | Parallel latency + availability check that runs before any delivery commitment.                                                                                                   |
+| **Selection score**    | A combined ranking over advertised price, observed latency, and reputation. Lower is better.                                                                                      |
+| **Stake**              | TOKEN locked on-chain by a node to join the mesh — a capacity bond that scales with declared bandwidth. Returned on deregistration after an unbonding period.                     |
+| **TOKEN**              | The deCDN staking token: locked as a node's capacity bond and burned by the buyback sink. Not used for payments; governance weight comes from delivered bytes, not TOKEN balance. |
+| **USDC**               | The payment currency for all delivery. Fixed at deployment; channels deposit, voucher, and settle in USDC.                                                                        |
+| **Voucher**            | A signed off-chain payment message. The primary payment instrument between client and node.                                                                                       |

--- a/docs/overview/how-it-works.mdx
+++ b/docs/overview/how-it-works.mdx
@@ -20,7 +20,7 @@ sequenceDiagram
     C->>N: Channel close / settle
 ```
 
-The client picks the candidate with the best combination of price, latency, and reputation. After settling on a node, it opens a channel in an allowlisted ERC-20 and streams. Vouchers cover every byte delivered; the node can settle any voucher on-chain later.
+The client picks the candidate with the best combination of price, latency, and reputation. After settling on a node, it opens a USDC channel and streams. Vouchers cover every byte delivered; the node can settle any voucher on-chain later.
 
 ## Cache miss with pull-through
 

--- a/docs/overview/introduction.mdx
+++ b/docs/overview/introduction.mdx
@@ -8,10 +8,10 @@ deCDN is a **decentralized content delivery network**. Instead of a single provi
 ## Core properties
 
 - **Content-addressed.** Every blob is identified by its BLAKE3 hash. Clients verify the bytes they receive — they do not trust any node to return the right content.
-- **Paid per megabyte.** Every byte delivered is paid, including node-to-node cache-miss pulls. Payments run on off-chain channels in governance-allowlisted ERC-20s, with on-chain settlement only at channel open and close.
+- **Paid per megabyte.** Every byte delivered is paid, including node-to-node cache-miss pulls. Payments run on off-chain channels denominated in USDC (fixed at deployment), with on-chain settlement only at channel open and close.
 - **Origin-hidden.** Origin backends (S3, R2, B2, NFS, local disk) are opaque per-node configuration. No external origin URL is ever exposed to the network.
 - **Staked and slashable.** Nodes stake TOKEN to join the peer mesh. Slashable offenses have on-chain evidence paths that anyone can challenge.
-- **No single operator.** Gossip for discovery. A DHT for content location. Optimistic challenge-response for disputes. Token-weighted governance with a timelock for parameter updates.
+- **No single operator.** Gossip for discovery. A DHT for content location. Optimistic challenge-response for disputes. Operator governance weighted by delivered bytes, with a timelock for parameter updates.
 
 ## What it isn't
 

--- a/docs/overview/participants.mdx
+++ b/docs/overview/participants.mdx
@@ -13,7 +13,7 @@ A **node** is a staked QUIC endpoint that caches and serves content-addressed bl
 - **Stake.** Required to join the mesh.
 - **Gossip.** Publishes node metadata on a global topic and a regional topic. Also emits rate-change updates.
 - **Delivery.** Serves the paid-delivery protocol — the sole rail for both client→node and node→node traffic.
-- **Earnings.** Per-MB voucher revenue in the channel's token — any governance-allowlisted ERC-20.
+- **Earnings.** Per-MB voucher revenue in USDC.
 
 Two deployment shapes:
 
@@ -30,7 +30,7 @@ A **client** is a lightweight QUIC endpoint that consumes content and pays for i
 
 - **Identity.** Ephemeral network keypair — no stake, no on-chain registration.
 - **Gossip.** Subscribes to topics but does not publish.
-- **Payment.** Opens an on-chain ERC-20 payment channel with each node it buys from, then signs off-chain vouchers as bytes flow ([payments](/protocol/payments)).
+- **Payment.** Opens an on-chain USDC payment channel with each node it buys from, then signs off-chain vouchers as bytes flow ([payments](/protocol/payments)).
 - **Trust model.** Verifies hashes on all bytes received. Trusts nodes for availability (slashable if claimed and not delivered), not for content.
 
 Clients can run a multi-node parallel download for large files and resume crashed transfers from the last verified byte.

--- a/docs/protocol/governance.mdx
+++ b/docs/protocol/governance.mdx
@@ -1,11 +1,21 @@
 ---
 title: Governance
-description: Token-weighted governance with safety bounds and a sunsetted emergency multisig.
+description: Operator governance weighted by delivered bytes, with safety bounds and a sunsetted emergency multisig.
 ---
 
 ## Decision
 
-OpenZeppelin Governor with TOKEN voting, **4% quorum**, and a **2-day timelock**. All governable parameters have hardcoded safety bounds that governance cannot override. A **3-of-5 emergency multisig** can only pause contracts and add emergency blacklist entries, and has a **12-month sunset** enforced via an immutable constructor deadline. Governance can vote to extend the sunset by capped increments.
+OpenZeppelin Governor whose voting weight is an operator's **delivered bytes over a trailing window** — not TOKEN balance — with a **4% quorum** and a **2-day timelock**. All governable parameters have hardcoded safety bounds that governance cannot override. A **3-of-5 emergency multisig** can pause contracts, add emergency blacklist entries, and triage disputed slashes and blacklist entries, and has a **12-month sunset** enforced via an immutable constructor deadline. Governance can vote to extend the sunset by capped increments.
+
+## Voting weight
+
+Voting weight is each operator's **served bytes over a trailing window** (default ~1 quarter, governable), scaled by a tenure ramp and capped per operator (default 5% of the window's bytes).
+
+- **Passive TOKEN holders have no vote.** Governance power tracks real delivery, not holdings — you must operate a node and serve bytes to vote.
+- **Fresh operators ramp in.** A new operator that serves heavily on day one still votes at a fraction of its byte share until the tenure ramp completes over several months.
+- **Slashing zeroes out the vote.** A slashed operator's weight drops to zero for the rest of the window, then recovers as the window slides past the slash.
+
+Bytes are read from the on-chain `FeeRouter` settlement counter, so weight is auditable and cannot be claimed without paid delivery.
 
 ## Hardcoded safety bounds
 
@@ -23,10 +33,11 @@ Bounds are enforced in `require()` checks in the setter functions. A malicious g
 
 ## Emergency multisig
 
-3-of-5 signers. Can only:
+3-of-5 signers. Limited to:
 
 - **Pause** any contract (`Pausable`)
 - **Add emergency blacklist entries** (with 14-day auto-expiry or 90-day for CSAM/terrorist categories — see [takedown](/protocol/takedown))
+- **Triage disputed slashes and blacklist entries** — fast-track or reject an appeal within a fixed window, never decide it unilaterally
 
 Can **not**:
 
@@ -38,16 +49,16 @@ Can **not**:
 
 ## Proposal flow
 
-1. Proposer holds ≥ proposal threshold TOKEN.
+1. Proposer's served-bytes weight ≥ the proposal threshold.
 2. `propose()` with target, calldata, description.
 3. Voting period (default 3 days).
-4. Quorum check (4% of circulating TOKEN).
+4. Quorum check — 4% of total delivered bytes in the trailing window.
 5. Queue in timelock (2 days).
 6. Execute.
 
 ## Why 4% quorum
 
-Low enough that realistic participation can reach quorum; high enough that a single whale cannot unilaterally pass a proposal. 4% maps to established DAO practice (Compound, Uniswap) and works in conjunction with the hardcoded safety bounds — the bounds mean a bad quorum can still only move parameters within the safe range.
+Low enough that realistic participation can reach quorum; high enough that no single operator can unilaterally pass a proposal — and the per-operator weight cap bounds concentration directly. 4% maps to established DAO practice (Compound, Uniswap) and works in conjunction with the hardcoded safety bounds — the bounds mean a bad quorum can still only move parameters within the safe range.
 
 ## Regional governance bodies
 

--- a/docs/protocol/payments.mdx
+++ b/docs/protocol/payments.mdx
@@ -1,11 +1,11 @@
 ---
 title: Payments
-description: Off-chain ERC-20 payment channels. Market-driven rates within governance-set bounds.
+description: Off-chain USDC payment channels. Market-driven rates within governance-set bounds.
 ---
 
 ## Decision
 
-Clients pay nodes **per MB** over off-chain **payment channels** settled on-chain. On a cache miss, nodes pay peers per MB for initial content pulls, then amortize that cost across many client deliveries. Origin-backed nodes set the effective price ceiling (their backend egress costs). Rates are fully market-driven within governance-set bounds.
+Clients pay nodes **per MB** over off-chain **payment channels** settled on-chain. All channels are denominated in **USDC**, fixed at contract deployment. On a cache miss, nodes pay peers per MB for initial content pulls, then amortize that cost across many client deliveries. Origin-backed nodes set the effective price ceiling (their backend egress costs). Rates are fully market-driven within governance-set bounds.
 
 ## Channel lifecycle
 
@@ -15,7 +15,7 @@ sequenceDiagram
     participant N as Node
     participant CH as PaymentChannel (on-chain)
 
-    C->>CH: openChannel(nodeAddr, deposit, token)
+    C->>CH: openChannel(nodeAddr, deposit)
     loop Per stream
         C->>N: Voucher (off-chain, signed)
     end
@@ -31,7 +31,7 @@ Off-chain signed messages bound to a specific channel. Each voucher supersedes p
 
 ## Rate discovery
 
-Each node advertises its own per-MB rate. Governance sets per-token bounds; a node advertising outside the bounds is ignored by selection. Rates can change between streams.
+Each node advertises its own per-MB rate. Governance sets rate bounds (in USDC); a node advertising outside the bounds is ignored by selection. Rates can change between streams.
 
 ## Dispute window
 

--- a/docs/protocol/takedown.mdx
+++ b/docs/protocol/takedown.mdx
@@ -48,4 +48,4 @@ Each node maintains a **local denylist** for direct legal notices (e.g., a DMCA 
 
 ## Slash schedule
 
-Blacklist violations use an escalating schedule: **10% / 25% / 50%** for first / second / third offense within 90 days.
+Blacklist violations use an escalating schedule: **5% / 15% / 50%** for first / second / third offense (capped at 50% per offense). Offenses accumulate over the operator's lifetime; a node whose bond falls below 50% of the minimum is auto-ejected.


### PR DESCRIPTION
## Summary

Audits the public Mintlify docs (`website/docs/`) against the source-of-truth `decdn/decdn` repo (ADRs, contracts, `CLAUDE.md`) and fixes claims that had drifted out of date.

### Stale facts corrected

1. **Payment token → single immutable USDC** (was "governance-allowlisted ERC-20s"). ADR 010 multi-token was dropped pre-launch; `PaymentChannel.sol` fixes USDC at deployment (ADR 003).
   - `introduction`, `participants`, `architecture`, `how-it-works`, `payments` (incl. dropping the `token` arg from the `openChannel` mermaid call and "per-token bounds" → "rate bounds in USDC").
2. **Governance voting weight → delivered-bytes** (was "TOKEN voting / 4% of circulating TOKEN"). ADR 036 makes `FeeRouter` served-bytes over a trailing window the canonical vote weight (tenure ramp + per-operator cap; passive holders have no vote; slashed operators zero out).
   - `governance.mdx`: Decision line, new **Voting weight** section, proposal-flow steps, quorum rationale, emergency-multisig appeal triage; `introduction` "Token-weighted" → "weighted by delivered bytes".
3. **Blacklist slash schedule → 5% / 15% / 50%** by lifetime offense count (was "10% / 25% / 50% within 90 days"). `CapacityBond.sol` tiers 500/1500/5000 bps; capped 50%/offense; auto-eject below 50% of min bond (ADR 026/011).

### Light polish
- `glossary`: rewrote the **TOKEN** entry, added a **USDC** term, noted capacity-bond staking.
- `design-decisions`: added **037 Regional proxy warming** (new ADR).

### Out of scope (intentionally unchanged)
- `slashing.mdx` "portion to challenger, remainder burned" — vague but still correct (50/50 finality).
- "stake" terminology kept; no new SlashAppeal/blacklist-appeal pages.

## Test plan

- [x] `prettier --check docs/overview docs/protocol` clean (and pre-commit markdownlint + prettier ran on commit)
- [x] grep confirms no remaining `allowlisted erc-20` / `token voting` / `circulating token` / `10% / 25%` / `per-token bounds` strings
- [x] each claim cross-checked against `adr/003-payments.md`, `adr/036-served-bytes-voting-weight.md`, `CapacityBond.sol`, `adr/011-content-takedown.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)