### PR TITLE
fix(faq): correct buyback share to 30% per ADR 026

### DIFF
--- a/lib/faq.ts
+++ b/lib/faq.ts
@@ -13,7 +13,7 @@ export const FAQ_ITEMS = [
   },
   {
     q: "Why does the network need a token?",
-    a: "TOKEN secures the network — operators stake it to participate, and they lose it if they misbehave. Payments, though, happen in USDC, because operators want stable currency they can pay power bills with. Twenty percent of protocol fees flow into a Balancer V3 80/20 TOKEN/USDC buyback, tying token demand to network throughput.",
+    a: "TOKEN secures the network — operators stake it to participate, and they lose it if they misbehave. Payments, though, happen in USDC, because operators want stable currency they can pay power bills with. Thirty percent of protocol fees flow into a Balancer V3 80/20 TOKEN/USDC buyback, tying token demand to network throughput.",
   },
   {
     q: "Can publishers pay on behalf of users?",


### PR DESCRIPTION
## What

Fix the buyback-and-burn percentage in the website FAQ: **20% → 30%**.

`lib/faq.ts` (the "Why does the network need a token?" answer) stated that *twenty* percent of protocol fees flow into the Balancer V3 80/20 TOKEN/USDC buyback. The canonical source — **ADR 026 (Tokenomics)** — defines the FeeRouter split as **60% operator base / 30% buyback-and-burn / 10% treasury**. The 30% figure is reinforced across ADRs 003, 009, and 016, and matches the Litepaper.

## Why

The website was internally inconsistent: `content/blog/00-what-were-building.mdx` already says "Thirty percent of every settlement is routed to buyback-and-burn" (corrected in c150bc7), but the FAQ was missed and still showed 20%. This change brings the FAQ in line with the blog post, the Litepaper, and the canonical ADRs.

## Scope check

Cross-checked every other tokenomics/numeric claim on the site (operator share 40–90%, burn floor ≥5%, slashing 5/15/50, 50/50 challenger/burn split, 4% quorum, 5% per-operator voting cap, ≥30 operators / ≥100 Gbps bootstrap exit, ~\$0.01/GB pricing) against the ADRs — all accurate. The FAQ's 20% was the only stale figure.

## Verification

- `pnpm lint` — clean
- `pnpm test` — 101/101 pass
- `pnpm build` — static export succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)