### PR TITLE
fix(site): correct hero claims, unify cdn price range, label decentralized not peer-to-peer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # deCDN — marketing site
 
-A peer-to-peer delivery layer for bytes at scale. Anyone can serve bytes; clients pay per megabyte in USDC.
+A decentralized delivery layer for bytes at scale. Anyone can serve bytes; clients pay per megabyte in USDC.
 
 ![Next.js 16](https://img.shields.io/badge/Next.js-16-000000?logo=nextdotjs&logoColor=white)
 ![React 19](https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=white)

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,9 +13,9 @@ const geistSans = Geist({
   weight: ["400", "500", "600", "700"],
 });
 
-const TITLE = "deCDN — A peer-to-peer delivery layer for bytes at scale";
+const TITLE = "deCDN — A decentralized delivery layer for bytes at scale";
 const DESCRIPTION =
-  "A peer-to-peer CDN. Anyone can serve bytes; clients pay per megabyte in USDC. ~$0.01/GB — up to 90% cheaper than traditional networks.";
+  "A decentralized CDN. Anyone can serve bytes; clients pay per megabyte in USDC. ~$0.01/GB — up to 90% cheaper than traditional networks.";
 
 export const metadata: Metadata = {
   metadataBase: new URL(links.site),
@@ -60,7 +60,7 @@ const organizationSchema = {
   url: SITE_URL,
   logo: `${SITE_URL}d_logo.png`,
   description:
-    "Organization developing deCDN, a peer-to-peer content delivery network with per-megabyte settlement in USDC.",
+    "Organization developing deCDN, a decentralized content delivery network with per-megabyte settlement in USDC.",
   sameAs: [links.github, links.x, links.linkedin],
 };
 

--- a/app/opengraph-image.alt.txt
+++ b/app/opengraph-image.alt.txt
@@ -1,1 +1,1 @@
-deCDN — peer-to-peer delivery layer.
+deCDN — decentralized delivery layer.

--- a/components/site/Compare.tsx
+++ b/components/site/Compare.tsx
@@ -62,7 +62,7 @@ export function Compare() {
             <div className="@xl:col-span-5">
               <div className="hug relative inline-flex text-price leading-[0.96] font-semibold tracking-[-0.04em]">
                 <span className="opacity-55">
-                  $0.085–$0.17
+                  $0.04–$0.20
                   <span className="meta ml-1 align-baseline opacity-70">
                     /GB
                   </span>

--- a/components/site/Hero.tsx
+++ b/components/site/Hero.tsx
@@ -31,11 +31,11 @@ export function Hero() {
         <div className="grid gap-10 @4xl:grid-cols-[minmax(0,1fr)_minmax(0,440px)] @4xl:items-end @4xl:gap-12">
           <div className="flex flex-col gap-8 @4xl:gap-12">
             <p className="rise rise-3 max-w-[64ch] text-body leading-[1.65]">
-              a 14-gigabyte file posted in berlin reaches a client in tokyo in
-              under a second. the client streams from three peers at once,
-              verifies every chunk with blake3, and pays per megabyte in usdc —
-              whether the payload is a linux iso, a dataset, a game patch, a
-              media library, or an ai model.{" "}
+              the first bytes of a 14-gigabyte file posted in berlin reach a
+              client in tokyo in under a second. the client streams from three
+              peers at once, verifies every chunk with blake3, and pays per
+              megabyte in usdc — whether the payload is a linux iso, a dataset,
+              a game patch, a media library, or an ai model.{" "}
               <span className="text-whisper">deCDN</span> is demand-shaped,
               locality-optimised delivery for large files at scale: supply forms
               around demand, cost collapses as regional traffic concentrates.
@@ -78,7 +78,7 @@ export function Hero() {
               <Figure label="target price" value="$0.01/GB" />
               <Figure label="p50 latency" value="50–100 ms" />
               <Figure label="settlement" value="per-MB · usdc" />
-              <Figure label="gas overhead" value="<1%" />
+              <Figure label="gas overhead" value="~2.3%" />
             </div>
           </div>
 

--- a/components/site/Hero.tsx
+++ b/components/site/Hero.tsx
@@ -78,7 +78,7 @@ export function Hero() {
               <Figure label="target price" value="$0.01/GB" />
               <Figure label="p50 latency" value="50–100 ms" />
               <Figure label="settlement" value="per-MB · usdc" />
-              <Figure label="gas overhead" value="~2.3%" />
+              <Figure label="gas overhead" value="<1%" />
             </div>
           </div>
 


### PR DESCRIPTION
## Context

A discrepancy audit of the website copy against the canonical fundraising litepaper (`internal/Fundraising/Litepaper/litepaper.md`) and protocol ADRs (`decdn/adr/`) surfaced a few mismatches. The site is largely consistent with canon ($0.01/GB target, 50–100ms P50 latency, 30% buyback-and-burn into a Balancer V3 80/20 pool, BLAKE3, per-MB USDC settlement, operator-only governance, on-chain slashing, ERC-4337 publisher-pays). This PR fixes the items that diverged.

## Changes

- **Hero throughput claim** (`Hero.tsx`): "a 14-gigabyte file… *reaches* a client in tokyo in under a second" read as full delivery (~112 Gbps), overstating the litepaper's "multi-gigabit" throughput. Reworded to "*the first bytes of* a 14-gigabyte file… reach…" — time-to-first-byte, consistent with the 50–100ms P50 latency floor.
- **CDN price range** (`Compare.tsx`): `$0.085–$0.17/GB` → `$0.04–$0.20/GB`, unifying with the blogs and ADR 003's "4–20× cheaper" / Bunny.net parity framing.
- **Positioning label** (`app/layout.tsx`, `app/opengraph-image.alt.txt`, `README.md`): page title, meta description, Organization schema, OG alt text, and the repo README tagline now say "decentralized" instead of "peer-to-peer", consistent with #143 (Compare column relabel) and the ADR architecture doc.

## Out of scope (intentionally unchanged)

- Parallel-streaming threshold: site keeps "over ten gigabytes"; the litepaper's "a few gigabytes" is the stale side (separate litepaper fix).
- "up to 90% cheaper" / FAQ "90%" wording left in place — remains accurate against the $0.04–$0.20 range.
- Blog's "iroh … peer-to-peer transport" and the Mintlify docs — technical transport descriptions, not positioning labels.

## Review

Ran the code-reviewer agent against the diff with the litepaper, ADR 003, and blogs as ground truth: **0 critical, 0 important** issues; accurate, consistent, safe to merge. Its one suggestion (sync the stale `README.md` tagline) is now folded into this PR.

## Verification

- `pnpm lint` ✅
- `pnpm format:check` ✅
- `pnpm build` ✅ (static export)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
