### PR TITLE
fix(content): correct stale slashing/staking claims in FAQ + blog

### DIFF
--- a/content/blog/02-decentralized-cdn-graveyard.mdx
+++ b/content/blog/02-decentralized-cdn-graveyard.mdx
@@ -33,7 +33,7 @@ Token-incentivized P2P video delivery layered as a sidecar to existing CDNs. The
 
 ## Livepeer (2018–)
 
-Livepeer is a transcoding marketplace, not a delivery network — but it shipped the volatility split from day one: ETH for job payments, LPT for staking. That two-currency design is the same shape we use (USDC for payments, TOKEN for staking), and the fact that the earliest decentralized compute marketplace arrived at it from launch is itself a validation. The lesson we take is that paying operators in your own volatile native token is the thing serious networks either avoid from the start or eventually migrate away from.
+Livepeer is a transcoding marketplace, not a delivery network — but it shipped the volatility split from day one: ETH for job payments, LPT for staking. That two-currency design is the same shape we use (USDC for payments, TOKEN for bonding), and the fact that the earliest decentralized compute marketplace arrived at it from launch is itself a validation. The lesson we take is that paying operators in your own volatile native token is the thing serious networks either avoid from the start or eventually migrate away from.
 
 Livepeer's other constraint: it's compute, not delivery. The transcoded output still has to land somewhere, and that somewhere is — in practice — a centralized CDN. Livepeer is a complementary network to ours, not a competitor.
 

--- a/lib/faq.ts
+++ b/lib/faq.ts
@@ -5,11 +5,11 @@ export const FAQ_ITEMS = [
   },
   {
     q: "How is byte-level integrity enforced?",
-    a: "Every blob is BLAKE3-addressed, so the hash the client is asking for is the same hash they'll be checking on the way in. Verification happens chunk-by-chunk, in flight — mismatched bytes are dropped and the next peer on the list is asked instead. Peers that send garbage don't get paid for it: the mismatch is caught in flight and the bytes dropped. On-chain misbehaviour (phantom availability, rate manipulation, blacklist violations) is slashed against the peer's bonded TOKEN at submit time, from an EIP-712 signed message rather than a central arbiter. The math is the arbiter.",
+    a: "Every blob is BLAKE3-addressed, so the hash the client is asking for is the same hash they'll be checking on the way in. Verification happens chunk-by-chunk, in flight — mismatched bytes are dropped and the next peer on the list is asked instead. Peers that send garbage don't get paid for it: the mismatch is caught in flight and the bytes dropped. On-chain misbehavior (phantom availability, rate manipulation, blacklist violations) is slashed against the peer's capacity bond at submit time, from an EIP-712 signed message rather than a central arbiter. The math is the arbiter.",
   },
   {
     q: "Can content be gated or taken down?",
-    a: "Both. For gating: upload ciphertext instead of plaintext — nodes cache the encrypted blob without ever seeing inside, and your app holds the keys, handing them to clients over a separate authenticated channel. Subscription, paywall, whatever logic fits. For takedown: governance can flag specific BLAKE3 hashes as non-servable, and nodes that keep serving them past a short compliance window lose bonded TOKEN — slashing is on-chain, not a human call. Both the key gate and the flag list are auditable; compliance runs end-to-end, from origin onboarding to peer-level slashing, governance-owned and auditable throughout.",
+    a: "Both. For gating: upload ciphertext instead of plaintext — nodes cache the encrypted blob without ever seeing inside, and your app holds the keys, handing them to clients over a separate authenticated channel. Subscription, paywall, whatever logic fits. For takedown: governance can flag specific BLAKE3 hashes as non-servable, and nodes that keep serving them past a short compliance window lose part of their capacity bond — slashing is on-chain, not a human call. Both the key gate and the flag list are auditable; compliance runs end-to-end, from origin onboarding to peer-level slashing, governance-owned and auditable throughout.",
   },
   {
     q: "Why does the network need a token?",

--- a/lib/faq.ts
+++ b/lib/faq.ts
@@ -5,15 +5,15 @@ export const FAQ_ITEMS = [
   },
   {
     q: "How is byte-level integrity enforced?",
-    a: "Every blob is BLAKE3-addressed, so the hash the client is asking for is the same hash they'll be checking on the way in. Verification happens chunk-by-chunk, in flight — mismatched bytes are dropped and the next peer on the list is asked instead. Peers that send garbage lose staked TOKEN via a non-custodial Merkle proof. There is no central arbiter; the math is the arbiter.",
+    a: "Every blob is BLAKE3-addressed, so the hash the client is asking for is the same hash they'll be checking on the way in. Verification happens chunk-by-chunk, in flight — mismatched bytes are dropped and the next peer on the list is asked instead. Peers that send garbage don't get paid for it: the mismatch is caught in flight and the bytes dropped. On-chain misbehaviour (phantom availability, rate manipulation, blacklist violations) is slashed against the peer's bonded TOKEN at submit time, from an EIP-712 signed message rather than a central arbiter. The math is the arbiter.",
   },
   {
     q: "Can content be gated or taken down?",
-    a: "Both. For gating: upload ciphertext instead of plaintext — nodes cache the encrypted blob without ever seeing inside, and your app holds the keys, handing them to clients over a separate authenticated channel. Subscription, paywall, whatever logic fits. For takedown: governance can flag specific BLAKE3 hashes as non-servable, and nodes that keep serving them past a short compliance window lose staked TOKEN — slashing is on-chain, not a human call. Both the key gate and the flag list are auditable; compliance runs end-to-end, from origin onboarding to peer-level slashing, governance-owned and auditable throughout.",
+    a: "Both. For gating: upload ciphertext instead of plaintext — nodes cache the encrypted blob without ever seeing inside, and your app holds the keys, handing them to clients over a separate authenticated channel. Subscription, paywall, whatever logic fits. For takedown: governance can flag specific BLAKE3 hashes as non-servable, and nodes that keep serving them past a short compliance window lose bonded TOKEN — slashing is on-chain, not a human call. Both the key gate and the flag list are auditable; compliance runs end-to-end, from origin onboarding to peer-level slashing, governance-owned and auditable throughout.",
   },
   {
     q: "Why does the network need a token?",
-    a: "TOKEN secures the network — operators stake it to participate, and they lose it if they misbehave. Payments, though, happen in USDC, because operators want stable currency they can pay power bills with. Thirty percent of protocol fees flow into a Balancer V3 80/20 TOKEN/USDC buyback, tying token demand to network throughput.",
+    a: "TOKEN secures the network — operators post a slashable capacity bond to participate, and they lose it if they misbehave. Payments, though, happen in USDC, because operators want stable currency they can pay power bills with. Thirty percent of protocol fees flow into a Balancer V3 80/20 TOKEN/USDC buyback-and-burn, tying token demand to network throughput.",
   },
   {
     q: "Can publishers pay on behalf of users?",


### PR DESCRIPTION
Fixes public-facing copy that contradicts the canonical ADRs (surfaced while reframing cost positioning in #155).

## changes
- **`lib/faq.ts`**
  - "How is byte-level integrity enforced?" — dropped **"non-custodial Merkle proof"**; canonical slashing is **EIP-712 signed-message** at submit time (ADR 014). Also clarified that corrupted bytes are caught at the wire and simply not paid for, while the on-chain offenses (phantom availability, rate manipulation, blacklist violations) are what get slashed.
  - "Can content be gated or taken down?" — "staked TOKEN" → **"bonded TOKEN"**.
  - "Why does the network need a token?" — "operators **stake** it" → "operators post a slashable **capacity bond**" (ADR 026); "buyback" → "buyback-and-burn".
- **`content/blog/02-decentralized-cdn-graveyard.mdx`** — our side of the Livepeer analogy is "TOKEN for **bonding**", not "staking" (Livepeer's own "LPT for staking" is left, that's their term).

## why
Canonical: operators post a **capacity bond** (`CapacityBond`, ADR 026), not a stake; slashing is **EIP-712 signed-message** (ADR 014), not an interactive/non-custodial Merkle proof. These were live on the public site.

## overlap note
This touches the same slashing terminology as the in-flight `fix/slashing-three-offenses` branch but is scoped to public copy (FAQ + blog) only; no protocol/component code.

## checks
`pnpm lint` clean, `pnpm test` 101/101, `pnpm build` (static export) succeeds.