### PR TITLE
feat(blog): publish post 04 "stablecoin settlement is not a footnote"

### DIFF
--- a/content/blog/04-stablecoin-settlement-is-not-a-footnote.mdx
+++ b/content/blog/04-stablecoin-settlement-is-not-a-footnote.mdx
@@ -1,0 +1,65 @@
+---
+title: "Stablecoin Settlement Is Not a Footnote"
+slug: stablecoin-settlement-is-not-a-footnote
+date: 2026-06-12
+summary: "Every prior decentralized delivery network priced bandwidth in a token whose value could halve overnight. decdn settles delivery in USDC and reserves its native token for alignment — bonding, governance, and buyback-and-burn."
+bucket: pillar
+tags: [payments, usdc, tokenomics, operators]
+---
+
+Every prior decentralized delivery network priced bandwidth in something whose value could halve overnight. We don't. This is not an implementation detail. It is the single biggest reason most prior attempts couldn't keep their supply side, and it's the design choice that pays for itself before any other.
+
+## The operator P&L problem
+
+The thing decentralized infrastructure projects underestimate, over and over, is that the supply side is a small business. A node operator running a Hetzner CPX22 in Helsinki has a server bill of €7.99 a month. They pay it in euros. If their CDN earnings come in a token that's denominated in something else — a network-native asset, a governance coin, a "utility" token — then their revenue is a position in a foreign currency, marked to market every minute, and their server bill is a short position against that currency. They are now running a forex book whether they wanted to or not.
+
+Most operators don't want to run a forex book. They want to run servers. So when the token drops 40% on a Tuesday and their last month's earnings are now worth 60% of what they were when they were credited, they shut their nodes down. The supply side evaporates fastest exactly when you need it most — when token-market noise is high and the network needs to look stable.
+
+This isn't hypothetical. Filecoin's FIL has traded in a more-than-ten-times range. Theta's TFUEL/THETA pair drifts independently of fiat. MaidSafe's token never had a stable price reference at all. Storage providers and edge nodes who priced their service in any of these and had to pay servers in dollars were running at a loss against fiat-denominated bandwidth bills for substantial windows of time.
+
+## What we actually pay in
+
+decdn delivery is paid in **USDC**. Not in TOKEN. Not in a wrapped reference asset. Not in a "decentralized stablecoin" pegged to a basket of things that wobble. USDC, the same Circle-issued, monthly-attested, on-chain dollar that cleared trillions of dollars of volume in 2024 and is the de facto unit of account for on-chain finance. A node operator who books $300 in earnings keeps $300 of buying power. Their server bill is in dollars. Their revenue is in dollars. The two add up the way arithmetic says they should.
+
+This is what makes the operator P&L work as a small business. It's the same reason Stripe doesn't pay its merchants in Stripe shares.
+
+USDC payment channels open, top up, and settle using the same primitives as any other ERC-20. There's nothing experimental about the rails. We did not invent USDC; we did not invent ERC-20 channels; we did not invent the way a battle-tested signature checker handles EOA and ERC-1271 wallets uniformly. We composed all of it. That's a feature of "why now" — these primitives only became boring enough to depend on around 2023.
+
+## What TOKEN is for, and what it isn't
+
+We do issue a native token. It's called TOKEN. Its job is alignment, not payment.
+
+What TOKEN does:
+
+- **Bonding.** A node operator bonds TOKEN to register, sized to the capacity they declare — larger operators bond more, along a super-linear curve. The bond is slashable for the on-chain offenses: phantom announcements, rate manipulation, and serving blacklisted content. Skin in the game gives the network a credible enforcement mechanism without inventing a court system.
+- **Governance.** Voting weight comes from _proven delivered bytes_, not from locked or vote-escrowed tokens. Operators who actually move traffic steer protocol parameters — fee bounds, blacklist administration, the channel dispute window — through the on-chain governor. Influence tracks contribution, not balance.
+- **Value accrual through burn.** Thirty percent of every settlement is routed to buyback-and-burn: USDC swapped for TOKEN, the TOKEN burned. Demand is tied to actual network usage, and the deflation benefits every holder uniformly — no yield paid to anyone.
+
+What TOKEN is _not_ for:
+
+- Paying delivery. We bill in USDC.
+- Operator revenue. Operators earn USDC. The TOKEN they bond is locked capital, not income.
+- Pricing bandwidth. The market discovers per-MB pricing in dollars, denominated the same way as the operator's server bill.
+
+This split is what Livepeer migrated to _after_ launching with single-token economics; we ship it from genesis. The lesson is in the public record: networks that try to pay operators in their own native token eventually realize the volatility coupling is a structural problem, not a tuning problem, and they fork. Better to land there from day one.
+
+## The rails are now boring
+
+Five years ago, paying node operators on-chain meant designing a custom token, defending its market, and asking operators to take a position in your project's economic narrative. Five years later:
+
+- USDC and USDT clear the volume of meaningful payment networks. Settlement primitives are audited, attested, and battle-tested.
+- Layer-2 transaction costs are low enough ($0.05–0.10 per tx on the leading low-cost L2s) that opening, settling, and disputing a payment channel is a sub-dollar lifecycle. The full cycle on our target L2 is about $0.23.
+- ERC-4337 account abstraction lets Safe smart wallets batch approvals today, and — in production — pay gas in USDC and use session keys for high-frequency voucher signing without exposing the master key.
+- Circle's CCTP gives us native USDC bridging across L2s, removing the trust assumption of wrapped-token bridges.
+
+We did not need to design any of this. We needed to compose it. That's the leverage we get by being the network that ships now and not the one that shipped five years ago.
+
+## The bottom line
+
+If you're a node operator: your earnings track your server bill in the same currency. You don't need to think about token-market dynamics to run a profitable node. You think about latency and cache hit rate.
+
+If you're a content publisher: your delivery cost is denominated in dollars, the same as everything else on your invoice. Your monthly CDN line item is predictable.
+
+If you're a token holder: TOKEN demand comes from bonding, governance, and the buyback-and-burn — not from being forced into the medium-of-exchange role for a workload that needs sub-cent granularity. Token economics get to be about long-term alignment instead of short-term liquidity.
+
+This is what we mean by "stablecoin settlement is not a footnote." It's the design choice that makes every other piece of the protocol economically coherent. Pull this thread and the whole network unravels.


### PR DESCRIPTION
Publishes the next pillar post in the slate (00–03 already live) to the public site.

## What

Promotes `internal/Blog/04-stablecoin-settlement-is-not-a-footnote.md` to `content/blog/04-stablecoin-settlement-is-not-a-footnote.mdx`, applying the standard draft→publish transform (Title-Case title, added `summary` + `tags`, dropped `status: draft` and the H1/`Related:` footer, `*italic*`→`_italic_`, sentence-case headers).

- **date:** `2026-06-12` — two weeks after post 03 (2026-05-29), on the fortnightly cadence. Adjust if you want a different go-live date.

## ADR validation

Every economic/technical claim was checked against the ADRs and is current:

- Fee split 60/30/10, 30% buyback-and-burn — ADR 026
- Super-linear capacity-bond curve (`k × Mbps^α`) — ADR 019/026
- Governance by proven delivered bytes — ADR 036
- Three slashable offenses (phantom / rate manipulation / blacklist), 5/15/50 — ADR 028/026
- L2 costs ($0.05–0.10/tx, ~$0.23 full cycle) — ADR 003
- Safe / ERC-1271 / EOA uniform signature handling, session keys deferred to production — ADR 024
- Native USDC via CCTP — appendix-l2-deployment

**One correction vs the draft:** the draft presented "pay gas in USDC" as a present-tense capability. ADR 024 lists the gas-in-USDC paymaster as a *deferred Production addition* (Not required for PoC) — same status as session keys. Reworded so both deferred features sit under the "in production" hedge, leaving batch approvals (Multi Send, deployed) as present-tense.

## Verification

- `vitest run` — 101/101 pass (blog frontmatter/schema validation included)
- `next build` — succeeds; `/blog/stablecoin-settlement-is-not-a-footnote` + OG image generate (21/21 static pages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)