### PR TITLE
fix(chrome): land home at top without a sticky #intro fragment

### DIFF
--- a/components/site/Chrome.tsx
+++ b/components/site/Chrome.tsx
@@ -78,8 +78,9 @@ export function Chrome() {
           window.location.pathname + window.location.search,
         );
         // scrollTo's default behaviour defers to <html>'s
-        // motion-safe:scroll-smooth (and reduced-motion), mirroring the
-        // section path's scrollIntoView below.
+        // motion-safe:scroll-smooth, so it auto-honours reduced motion
+        // (the variant drops out → instant), mirroring the section path's
+        // scrollIntoView below.
         window.scrollTo({ top: 0 });
         return;
       }

--- a/components/site/Chrome.tsx
+++ b/components/site/Chrome.tsx
@@ -4,7 +4,11 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { links } from "@/lib/links";
-import { homeHashSectionId, shouldInterceptNavClick } from "@/lib/scroll";
+import {
+  HOME_SECTION_ID,
+  homeNavTarget,
+  shouldInterceptNavClick,
+} from "@/lib/scroll";
 import { MobileMenu } from "@/components/site/MobileMenu";
 import { resolveActiveSection } from "@/components/site/chrome-active";
 
@@ -56,8 +60,31 @@ export function Chrome() {
   const handleNavClick = useCallback(
     (e: React.MouseEvent<HTMLAnchorElement>) => {
       if (!shouldInterceptNavClick(e)) return;
-      const id = homeHashSectionId(e.currentTarget.getAttribute("href") ?? "");
-      if (id === null) return;
+      const target = homeNavTarget(e.currentTarget.getAttribute("href") ?? "");
+      if (target === null) return;
+
+      if (target.type === "top") {
+        // Home: land at the very top with no #intro fragment. Off this
+        // route the hero isn't in the DOM (e.g. /blog/*) — return without
+        // preventDefault so the native <Link href="/"> soft-navs home.
+        if (document.getElementById(HOME_SECTION_ID) === null) return;
+        e.preventDefault();
+        // Drop only the #fragment (keep any query); pathname+search is the
+        // canonical home. replaceState keeps a repeat click a URL no-op so
+        // nothing can accumulate.
+        history.replaceState(
+          null,
+          "",
+          window.location.pathname + window.location.search,
+        );
+        // scrollTo's default behaviour defers to <html>'s
+        // motion-safe:scroll-smooth (and reduced-motion), mirroring the
+        // section path's scrollIntoView below.
+        window.scrollTo({ top: 0 });
+        return;
+      }
+
+      const { id } = target;
       e.preventDefault();
       const el = document.getElementById(id);
       if (el === null) {
@@ -195,7 +222,7 @@ export function Chrome() {
     >
       <div className="mx-auto grid w-full max-w-frame grid-cols-[1fr_auto_1fr] items-center gap-4">
         <Link
-          href="/#intro"
+          href="/"
           onClick={handleNavClick}
           className="col-start-1 flex items-center gap-3 no-underline"
         >

--- a/components/site/MobileMenu.tsx
+++ b/components/site/MobileMenu.tsx
@@ -9,7 +9,7 @@ import {
 } from "react";
 import { createPortal } from "react-dom";
 import { links } from "@/lib/links";
-import { scrollToAnchor } from "@/lib/scroll";
+import { HOME_SECTION_ID, scrollToAnchor } from "@/lib/scroll";
 
 type SectionId = "intro" | "compare" | "method" | "faq" | "contact";
 
@@ -162,15 +162,18 @@ export function MobileMenu({ activeSection, tone, onOpenChange }: Props) {
 
       const anchor = pendingAnchorRef.current;
       pendingAnchorRef.current = null;
+      // intro is the top of the page, not a section deep-link: go to the
+      // very top and clear the hash rather than writing #intro (issue #157).
+      const isHome = anchor === HOME_SECTION_ID;
       const targetEl = anchor ? document.getElementById(anchor) : null;
 
       if (anchor && !targetEl) {
-        // Drawer opened from a different route (e.g. /blog/*); a
-        // full reload to /#anchor lets the new page handle the hash
-        // scroll deterministically (Next 16 App Router's soft-nav
-        // hash behaviour under output: "export" isn't documented).
+        // Drawer opened from a different route (e.g. /blog/*); a full
+        // reload lets the new page resolve the destination deterministically
+        // (Next 16 App Router's soft-nav hash behaviour under output:
+        // "export" isn't documented). Home -> "/", section -> "/#anchor".
         // Skip the local restore — the page is about to unload.
-        window.location.assign(`/#${anchor}`);
+        window.location.assign(isHome ? "/" : `/#${anchor}`);
         return;
       }
 
@@ -183,10 +186,21 @@ export function MobileMenu({ activeSection, tone, onOpenChange }: Props) {
       const html = document.documentElement;
       const prevScrollBehavior = html.style.scrollBehavior;
       html.style.scrollBehavior = "auto";
-      window.scrollTo(0, scrollYRef.current);
+      // Home lands at the top; a section restores the prior position so
+      // scrollToAnchor can animate from there.
+      window.scrollTo(0, isHome ? 0 : scrollYRef.current);
       html.style.scrollBehavior = prevScrollBehavior;
 
-      if (anchor && targetEl) {
+      if (isHome) {
+        // Clear any #section fragment — the top is canonical home, no
+        // #intro. Leave focusMovedToSectionRef false so the close effect
+        // returns focus to the toggle (top-right), correct for "to the top".
+        history.replaceState(
+          null,
+          "",
+          window.location.pathname + window.location.search,
+        );
+      } else if (anchor && targetEl) {
         // replaceState updates the URL without scrolling;
         // scrollToAnchor does the visible scroll.
         history.replaceState(null, "", `#${anchor}`);

--- a/components/site/MobileMenu.tsx
+++ b/components/site/MobileMenu.tsx
@@ -163,7 +163,7 @@ export function MobileMenu({ activeSection, tone, onOpenChange }: Props) {
       const anchor = pendingAnchorRef.current;
       pendingAnchorRef.current = null;
       // intro is the top of the page, not a section deep-link: go to the
-      // very top and clear the hash rather than writing #intro (issue #157).
+      // very top and clear the hash rather than writing #intro.
       const isHome = anchor === HOME_SECTION_ID;
       const targetEl = anchor ? document.getElementById(anchor) : null;
 

--- a/lib/scroll.test.ts
+++ b/lib/scroll.test.ts
@@ -17,6 +17,18 @@ describe("homeNavTarget", () => {
     expect(homeNavTarget(`/#${HOME_SECTION_ID}`)).toEqual({ type: "top" });
   });
 
+  it("matches the intro id exactly (case-sensitive, no normalization)", () => {
+    // The id compare is exact; only the lowercase ids callers emit fold to
+    // the top. "/#INTRO" stays a section (then misses getElementById).
+    expect(homeNavTarget("/#INTRO")).toEqual({ type: "section", id: "INTRO" });
+  });
+
+  it("returns null for a query before the intro hash (not a clean /#…)", () => {
+    // Symmetric with the "/?x=1#method" case: the query breaks the "/#"
+    // prefix, so a query-bearing home href is not recognized as the top.
+    expect(homeNavTarget("/?x=1#intro")).toBeNull();
+  });
+
   it("maps a section hash href to a section target", () => {
     expect(homeNavTarget("/#method")).toEqual({
       type: "section",

--- a/lib/scroll.test.ts
+++ b/lib/scroll.test.ts
@@ -1,35 +1,57 @@
 import { describe, expect, it } from "vitest";
 import {
-  homeHashSectionId,
+  HOME_SECTION_ID,
+  homeNavTarget,
   parseScrollMarginTop,
   shouldInterceptNavClick,
 } from "./scroll";
 
-describe("homeHashSectionId", () => {
-  it("returns the section id for a home-page hash href", () => {
-    expect(homeHashSectionId("/#method")).toBe("method");
-    expect(homeHashSectionId("/#intro")).toBe("intro");
-    expect(homeHashSectionId("/#contact")).toBe("contact");
+describe("homeNavTarget", () => {
+  it("maps the home root and the intro anchor to the top (no fragment)", () => {
+    expect(homeNavTarget("/")).toEqual({ type: "top" });
+    expect(homeNavTarget("/#intro")).toEqual({ type: "top" });
+  });
+
+  it("locks the home section id to intro", () => {
+    expect(HOME_SECTION_ID).toBe("intro");
+    expect(homeNavTarget(`/#${HOME_SECTION_ID}`)).toEqual({ type: "top" });
+  });
+
+  it("maps a section hash href to a section target", () => {
+    expect(homeNavTarget("/#method")).toEqual({
+      type: "section",
+      id: "method",
+    });
+    expect(homeNavTarget("/#contact")).toEqual({
+      type: "section",
+      id: "contact",
+    });
   });
 
   it("returns null when there is no target section", () => {
-    expect(homeHashSectionId("/#")).toBeNull();
-    expect(homeHashSectionId("/")).toBeNull();
+    expect(homeNavTarget("/#")).toBeNull();
   });
 
   it("returns null for a bare hash (resolves against current URL, not home)", () => {
-    expect(homeHashSectionId("#method")).toBeNull();
+    expect(homeNavTarget("#method")).toBeNull();
+    expect(homeNavTarget("#intro")).toBeNull();
   });
 
   it("returns null for cross-route navigation", () => {
-    expect(homeHashSectionId("/blog/foo")).toBeNull();
-    expect(homeHashSectionId("/blog/foo/#method")).toBeNull();
+    expect(homeNavTarget("/blog/foo")).toBeNull();
+    expect(homeNavTarget("/blog/foo/#method")).toBeNull();
   });
 
   it("does not sanitize multi-hash or trailing-slash input (callers pass clean ids)", () => {
-    expect(homeHashSectionId("/#method#method")).toBe("method#method");
-    expect(homeHashSectionId("/#intro/")).toBe("intro/");
-    expect(homeHashSectionId("/?x=1#method")).toBeNull();
+    expect(homeNavTarget("/#method#method")).toEqual({
+      type: "section",
+      id: "method#method",
+    });
+    expect(homeNavTarget("/#intro/")).toEqual({
+      type: "section",
+      id: "intro/",
+    });
+    expect(homeNavTarget("/?x=1#method")).toBeNull();
   });
 });
 

--- a/lib/scroll.ts
+++ b/lib/scroll.ts
@@ -1,6 +1,6 @@
 // `intro` is the id of the top (Hero) section. Its anchor is treated as
 // "go to the top, no fragment" rather than a section deep-link, so the URL
-// never carries a sticky `#intro` (issue #157).
+// never carries a sticky `#intro`.
 export const HOME_SECTION_ID = "intro";
 
 export type HomeNavTarget =

--- a/lib/scroll.ts
+++ b/lib/scroll.ts
@@ -17,6 +17,7 @@ export type HomeNavTarget =
 //   "#method"           -> null   (bare hash — resolves against the
 //                                  current URL, not home; not our concern)
 //   "/blog/foo/#method" -> null   (cross-route navigation)
+//   "/?x=1#method"      -> null   (query before the hash — not "/#…")
 //
 // Callers pass a clean `/#${id}`; this does not sanitize multi-hash or
 // trailing-slash input (`/#a#b` -> section "a#b", `/#intro/` -> section

--- a/lib/scroll.ts
+++ b/lib/scroll.ts
@@ -1,19 +1,34 @@
-// Returns the section id for a home-page hash href, or null when the href
-// is not an in-page anchor we should resolve locally.
+// `intro` is the id of the top (Hero) section. Its anchor is treated as
+// "go to the top, no fragment" rather than a section deep-link, so the URL
+// never carries a sticky `#intro` (issue #157).
+export const HOME_SECTION_ID = "intro";
+
+export type HomeNavTarget =
+  | { type: "top" } // home — scroll to the top and clear the hash
+  | { type: "section"; id: string }; // a section anchor — scroll + set the hash
+
+// Classifies a home-nav href into the local action to take, or null when the
+// href is not an in-page target we should resolve locally.
 //
-//   "/#method"          -> "method"
-//   "/#"  | "/"         -> null   (no target section)
+//   "/"                 -> { type: "top" }                 (canonical home)
+//   "/#intro"           -> { type: "top" }                 (intro IS the top)
+//   "/#method"          -> { type: "section", id: "method" }
+//   "/#"                -> null   (no target section)
 //   "#method"           -> null   (bare hash — resolves against the
 //                                  current URL, not home; not our concern)
 //   "/blog/foo/#method" -> null   (cross-route navigation)
 //
 // Callers pass a clean `/#${id}`; this does not sanitize multi-hash or
-// trailing-slash input (`/#a#b` -> "a#b", `/#intro/` -> "intro/").
-// Pure and DOM-free so the desktop nav click decision is unit-testable.
-export function homeHashSectionId(href: string): string | null {
+// trailing-slash input (`/#a#b` -> section "a#b", `/#intro/` -> section
+// "intro/"). Pure and DOM-free so the desktop nav click decision is
+// unit-testable.
+export function homeNavTarget(href: string): HomeNavTarget | null {
+  if (href === "/") return { type: "top" };
   if (!href.startsWith("/#")) return null;
   const id = href.slice(2);
-  return id.length > 0 ? id : null;
+  if (id.length === 0) return null;
+  if (id === HOME_SECTION_ID) return { type: "top" };
+  return { type: "section", id };
 }
 
 // Whether a nav click should be intercepted for local hash resolution,


### PR DESCRIPTION
## Summary

Clicking the wordmark/logo (or the mobile drawer's "home" link) always wrote `#intro` into the address bar via `history.replaceState`, because `intro` is the `id` of the top (Hero) section. The URL constantly ended up at `/#intro` and stuck there across reloads, making the canonical homepage look like a deep-linked section.

This treats the top of the page as fragment-free home: going "home" lands at the very top with a clean `/` URL, while the existing hash-accumulation guard (#116) stays intact for real sections.

## Changes

- **`lib/scroll.ts`** — Replace `homeHashSectionId` (returned a bare id) with a `HOME_SECTION_ID = "intro"` sentinel and a discriminated-union classifier `homeNavTarget(href)`: `{ type: "top" }` for `/` and `/#intro`, `{ type: "section", id }` for other anchors, or `null`.
- **`components/site/Chrome.tsx`** — Logo `href` is now `/` (no-JS-friendly canonical home). `handleNavClick` branches on the target: for `top`, it returns without `preventDefault` when off-route (lets `<Link href="/">` soft-nav home), else clears only the `#fragment` (preserving any query) and `scrollTo({ top: 0 })` — deferring to CSS `motion-safe:scroll-smooth`/reduced-motion, mirroring the section path. Section handling unchanged.
- **`components/site/MobileMenu.tsx`** — The drawer "home" link stays `href="#intro"`; the open-effect cleanup special-cases `isHome`: off-route reloads to `/` (not `/#intro`), on-route lands at the top and clears the fragment, leaving focus to return to the toggle.
- **`lib/scroll.test.ts`** — Rewrote the helper suite for `homeNavTarget` (top/section/null cases) plus a `HOME_SECTION_ID === "intro"` lock.

## Verification

- `pnpm test` — 103 passed
- `pnpm lint` — clean
- `pnpm build` (static export) — succeeds

Manual: section click → `/#method`; logo click → `/` (no fragment), smooth-scroll to top; repeat logo clicks stay `/` (no accumulation); from `/blog/*` logo soft-navs to `/`; mobile drawer "home" closes and lands at top with `/`.

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)