### PR TITLE
feat(blog): publish post 06 "show me the money"

### DIFF
--- a/content/blog/06-show-me-the-money.mdx
+++ b/content/blog/06-show-me-the-money.mdx
@@ -31,7 +31,7 @@ This is what makes caching skill matter. A node that holds the right blobs becom
 
 (That round number isn't branding: the model treats 100 TB as 100,000 GB and bills per megabyte at the protocol's $0.00001/MB rate, counting 1 GB as 1,024 MB. So 100,000 × 1,024 × $0.00001 = $1,024 exactly.)
 
-This is gross billing, before the FeeRouter split. decdn has no flat "protocol fee" and no discount tier to stake for. Instead, every client→node settlement is split on-chain in the transaction that closes the channel: **60% goes straight to the operator in USDC, 30% to buyback-and-burn, 10% to the protocol treasury**. Node-to-node cache-miss pulls bypass the split entirely — when this node serves a peer, the peer pays it directly, with no skim.
+This is gross billing, before the FeeRouter split. decdn has no flat "protocol fee" and no discount tier to bond for. Instead, every client→node settlement is split on-chain in the transaction that closes the channel: **60% goes straight to the operator in USDC, 30% to buyback-and-burn, 10% to the protocol treasury**. Node-to-node cache-miss pulls bypass the split entirely — when this node serves a peer, the peer pays it directly, with no skim.
 
 So the $1,024 splits by where the bytes went:
 

--- a/content/blog/06-show-me-the-money.mdx
+++ b/content/blog/06-show-me-the-money.mdx
@@ -27,7 +27,7 @@ This is what makes caching skill matter. A node that holds the right blobs becom
 
 ## The revenue line
 
-100 TB × $0.01/GB = $1,024.
+100 TB × $0.01/GB ≈ $1,024.
 
 (That round number isn't branding: the model treats 100 TB as 100,000 GB and bills per megabyte at the protocol's $0.00001/MB rate, counting 1 GB as 1,024 MB. So 100,000 × 1,024 × $0.00001 = $1,024 exactly.)
 
@@ -88,4 +88,4 @@ That's the operator past the launch ramp but not yet at scale — $40/month of l
 
 The thing that makes decdn's unit economics close where prior decentralized delivery networks didn't is the combination of three things. The currency is a stablecoin, so revenue and costs are in the same denomination. The settlement is on an L2, so per-MB billing has sub-cent granularity without on-chain transaction fees swamping the price. And every byte — including the ones flowing between nodes on a cache miss — is paid, so popular content propagates with an economic gradient instead of a polite request that someone please please cache it.
 
-Run the numbers on your own region, your own provider, your own expected utilization. The launch-ramp subsidy covers operators through cold-start (first 6 months); break-even hits around 5 TB/month per node; everything above that is real money in a stable currency.
+Run the numbers on your own region, your own provider, your own expected utilization. The launch-ramp subsidy covers operators through cold-start; break-even hits around 5 TB/month per node; everything above that is real money in a stable currency.

--- a/content/blog/06-show-me-the-money.mdx
+++ b/content/blog/06-show-me-the-money.mdx
@@ -21,7 +21,7 @@ Market rate of **$0.01/GB** is the public expected price — roughly 8–20× ch
 
 Of the 100 TB this node serves, roughly 70 TB goes directly to clients and 30 TB goes to other nodes pulling cache misses. Both are paid. Both are revenue.
 
-Why the split? Because every byte transferred — client to node *and* node to node — is paid in decdn. When a peer node has a cache miss for a blob this node is holding, the peer probes, finds this node has it, and pulls the bytes by opening or extending a payment channel against this node's NodeId. From this node's perspective, that's identical to a client request: signed vouchers come in, USDC settles when the channel closes.
+Why the split? Because every byte transferred — client to node _and_ node to node — is paid in decdn. When a peer node has a cache miss for a blob this node is holding, the peer probes, finds this node has it, and pulls the bytes by opening or extending a payment channel against this node's NodeId. From this node's perspective, that's identical to a client request: signed vouchers come in, USDC settles when the channel closes.
 
 This is what makes caching skill matter. A node that holds the right blobs becomes a paying source for the next hop. Margin amplifies through caching, not through raw throughput.
 
@@ -58,29 +58,29 @@ Total costs: ~$259 (cache-miss pulls $154 + infrastructure $95 + gas $10).
 
 ## The bottom line
 
-| Line | Amount |
-|---|---|
-| Client billing (≈70 TB), operator's 60% base share | +$430 |
-| Peer-serving (≈30 TB), no skim | +$307 |
-| Cache-miss pulls (15 TB × wholesale) | −$154 |
-| Infrastructure | −$95 |
-| L2 gas | −$10 |
-| **Net liquid USDC** | **+$478** |
+| Line                                               | Amount    |
+| -------------------------------------------------- | --------- |
+| Client billing (≈70 TB), operator's 60% base share | +$430     |
+| Peer-serving (≈30 TB), no skim                     | +$307     |
+| Cache-miss pulls (15 TB × wholesale)               | −$154     |
+| Infrastructure                                     | −$95      |
+| L2 gas                                             | −$10      |
+| **Net liquid USDC**                                | **+$478** |
 
 That's **$478/month of liquid USDC** at the launch-fleet target — about 47% of billed revenue, on mid-cost hosting. Cheaper infrastructure or a higher cache-hit rate pushes it up; the EU low-cost setup (Hetzner CPX22, ~$95 infra) is already baked into the figure.
 
-Two things make the operator's *aligned* return larger than the liquid-USDC line. The 30% of client billing routed to buyback-and-burn ($215 here) is USDC swapped for TOKEN and burned — deflation that accrues to the operator as a bond-holder, not to a passive third party; counting the 60% direct plus the 30% burn, the protocol's **operator-aligned share is 90%**. And through the first 12 months, pre-seed USDC subsidies cover early-operator infrastructure, so launch-period unit economics are positive before the network reaches steady state.
+Two things make the operator's _aligned_ return larger than the liquid-USDC line. The 30% of client billing routed to buyback-and-burn ($215 here) is USDC swapped for TOKEN and burned — deflation that accrues to the operator as a bond-holder, not to a passive third party; counting the 60% direct plus the 30% burn, the protocol's **operator-aligned share is 90%**. And through the first 12 months, pre-seed USDC subsidies cover early-operator infrastructure, so launch-period unit economics are positive before the network reaches steady state.
 
 ## The smaller scenario, for comparison
 
 A 10 TB/month node — early-traction, well within the Hetzner CPX22 included bandwidth allowance, no overage:
 
-| Line | Amount |
-|---|---|
-| Client billing (≈7 TB), 60% base share | +$43 |
-| Peer-serving (≈3 TB), no skim | +$31 |
-| Cache-miss pulls + infrastructure + gas | −$34 |
-| **Net liquid USDC** | **+$40** |
+| Line                                    | Amount   |
+| --------------------------------------- | -------- |
+| Client billing (≈7 TB), 60% base share  | +$43     |
+| Peer-serving (≈3 TB), no skim           | +$31     |
+| Cache-miss pulls + infrastructure + gas | −$34     |
+| **Net liquid USDC**                     | **+$40** |
 
 That's the operator past the launch ramp but not yet at scale — $40/month of liquid USDC, positive once you count the burn-driven alignment and the year-one infrastructure subsidy. Enough to cover their own self-paid AWS bill and a coffee.
 

--- a/content/blog/06-show-me-the-money.mdx
+++ b/content/blog/06-show-me-the-money.mdx
@@ -1,0 +1,91 @@
+---
+title: "Show Me the Money: A 100-TB/Month Node, Line by Line"
+slug: show-me-the-money
+date: 2026-06-22
+summary: "A single decdn node at the 100-TB/month launch-fleet target, walked line by line: $1,024 billed, $478 left in liquid USDC after the FeeRouter split, cache-miss pulls, infrastructure, and gas."
+bucket: operator
+tags: [operators, economics, payments, usdc]
+---
+
+$1,024 billed. $478 left, in liquid USDC.
+
+That's the headline P&L for a single decdn node hitting the launch-fleet target — 100 TB of traffic in a month, at a market rate of $0.01/GB. This post walks the line items.
+
+## The scenario
+
+Production launch fleet target. One node. Hetzner CPX22 with bandwidth overage, or equivalently a 1 Gbps unmetered dedicated tier (the cost structures converge above 100 TB/month — overage on a metered VPS approaches and eventually exceeds the flat-rate cost of an unmetered dedicated server). The node is healthy: it accepts client traffic, it pulls cache misses from peers, it serves 100 TB of bytes that month total.
+
+Market rate of **$0.01/GB** is the public expected price — roughly 8–20× cheaper than incumbent CDN list pricing (CloudFront $0.085/GB, Akamai $0.12–$0.20/GB) and at parity with budget CDN tiers. Operators set their own rate per-node; the market filters who wins which traffic.
+
+## The traffic split
+
+Of the 100 TB this node serves, roughly 70 TB goes directly to clients and 30 TB goes to other nodes pulling cache misses. Both are paid. Both are revenue.
+
+Why the split? Because every byte transferred — client to node *and* node to node — is paid in decdn. When a peer node has a cache miss for a blob this node is holding, the peer probes, finds this node has it, and pulls the bytes by opening or extending a payment channel against this node's NodeId. From this node's perspective, that's identical to a client request: signed vouchers come in, USDC settles when the channel closes.
+
+This is what makes caching skill matter. A node that holds the right blobs becomes a paying source for the next hop. Margin amplifies through caching, not through raw throughput.
+
+## The revenue line
+
+100 TB × $0.01/GB = $1,024.
+
+(That round number isn't branding: the model treats 100 TB as 100,000 GB and bills per megabyte at the protocol's $0.00001/MB rate, counting 1 GB as 1,024 MB. So 100,000 × 1,024 × $0.00001 = $1,024 exactly.)
+
+This is gross billing, before the FeeRouter split. decdn has no flat "protocol fee" and no discount tier to stake for. Instead, every client→node settlement is split on-chain in the transaction that closes the channel: **60% goes straight to the operator in USDC, 30% to buyback-and-burn, 10% to the protocol treasury**. Node-to-node cache-miss pulls bypass the split entirely — when this node serves a peer, the peer pays it directly, with no skim.
+
+So the $1,024 splits by where the bytes went:
+
+- Client traffic (≈70 TB → $717 billed): operator keeps the 60% base share = **$430** in liquid USDC; $215 funds buyback-and-burn, $72 the treasury.
+- Peer-serving (≈30 TB → $307): paid peer-to-peer, no skim, so the operator keeps **all $307**.
+- Operator USDC inflow: **$737**.
+
+## The cost lines
+
+**Cache miss pulls.** When a client requests a blob this node doesn't have, the node has two options: serve a redirect (return an origin NodeId, let the client connect there directly), or pay a peer to pull the bytes through (cache the result locally and stream to the client simultaneously). The pull-through path is the default and the better business — it keeps the client on this node's channel, captures the per-MB revenue, and warms the cache for the next request.
+
+At a healthy 85% cache hit rate, 15% of the traffic is a paid pull from a peer. The wholesale rate a node pays to pull from a peer is the same market — somewhere around the same $0.01/GB price band. So:
+
+- 15% × 100 TB = 15 TB pulled from peers
+- 15 TB × $0.01/GB ≈ $154 in node-to-node payments out
+
+That's the most operator-significant cost line, and it's the one most operators don't budget for on day one. Cache miss pulls are real money. The thing that makes them sustainable is the same thing that makes them necessary: the bytes they bring in get re-served, repeatedly, at a margin.
+
+**Infrastructure.** A Hetzner CPX22 base plus bandwidth overage at 100 TB/month comes to about **$95/month**. A 1 Gbps unmetered dedicated tier is a touch cheaper all-in — roughly $85 flat port plus the gas line below — so the $95 here is the conservative anchor.
+
+**L2 gas.** A full channel lifecycle (open, close, settle) costs about **$0.23** in gas on the L2, a settle-only update about $0.08. Across a month of opening and settling channels the model budgets **$10** at mid Arbitrum fee markets — and flags a revisit if sustained settlement gas ever crosses $1.00.
+
+Total costs: ~$259 (cache-miss pulls $154 + infrastructure $95 + gas $10).
+
+## The bottom line
+
+| Line | Amount |
+|---|---|
+| Client billing (≈70 TB), operator's 60% base share | +$430 |
+| Peer-serving (≈30 TB), no skim | +$307 |
+| Cache-miss pulls (15 TB × wholesale) | −$154 |
+| Infrastructure | −$95 |
+| L2 gas | −$10 |
+| **Net liquid USDC** | **+$478** |
+
+That's **$478/month of liquid USDC** at the launch-fleet target — about 47% of billed revenue, on mid-cost hosting. Cheaper infrastructure or a higher cache-hit rate pushes it up; the EU low-cost setup (Hetzner CPX22, ~$95 infra) is already baked into the figure.
+
+Two things make the operator's *aligned* return larger than the liquid-USDC line. The 30% of client billing routed to buyback-and-burn ($215 here) is USDC swapped for TOKEN and burned — deflation that accrues to the operator as a bond-holder, not to a passive third party; counting the 60% direct plus the 30% burn, the protocol's **operator-aligned share is 90%**. And through the first 12 months, pre-seed USDC subsidies cover early-operator infrastructure, so launch-period unit economics are positive before the network reaches steady state.
+
+## The smaller scenario, for comparison
+
+A 10 TB/month node — early-traction, well within the Hetzner CPX22 included bandwidth allowance, no overage:
+
+| Line | Amount |
+|---|---|
+| Client billing (≈7 TB), 60% base share | +$43 |
+| Peer-serving (≈3 TB), no skim | +$31 |
+| Cache-miss pulls + infrastructure + gas | −$34 |
+| **Net liquid USDC** | **+$40** |
+
+That's the operator past the launch ramp but not yet at scale — $40/month of liquid USDC, positive once you count the burn-driven alignment and the year-one infrastructure subsidy. Enough to cover their own self-paid AWS bill and a coffee.
+
+## Why the math works
+
+The thing that makes decdn's unit economics close where prior decentralized delivery networks didn't is the combination of three things. The currency is a stablecoin, so revenue and costs are in the same denomination. The settlement is on an L2, so per-MB billing has sub-cent granularity without on-chain transaction fees swamping the price. And every byte — including the ones flowing between nodes on a cache miss — is paid, so popular content propagates with an economic gradient instead of a polite request that someone please please cache it.
+
+Run the numbers on your own region, your own provider, your own expected utilization. The launch-ramp subsidy covers operators through cold-start (first 6 months); break-even hits around 5 TB/month per node; everything above that is real money in a stable currency.


### PR DESCRIPTION
Publishes blog post 06, **show me the money** — a line-by-line operator P&L for a 100-TB/month node ($1,024 billed → $478 net liquid USDC). Next in the operator slate after the road-to-testnet operator call.

## Fact-check (done before publishing)
Ran the finance model (`_shared/params.py` + `scenarios.py`) and cross-checked ADR 026. Every headline number validates exactly: revenue $1,024, client/peer $717/$307, 60/30/10 split ($430/$215/$72), inflow $737, cache-miss pull $154, **net $478 (46.7%)**, small-node $40. Peer-pulls-bypass-the-split and the 90% operator-aligned share both confirmed against ADR 026 §FeeRouter (lines 199, 203).

## Corrections applied vs. the draft
- **L2 gas**: draft said "$0.50–$1.50 per settlement" (a misread of the $1.00 revisit *threshold*); params put a full channel lifecycle at $0.23. Rewrote; kept the $10/mo mid budget.
- **$1,024 derivation**: was wrongly attributed to "TB = 1,024 GB"; it's 100,000 GB × 1,024 MB/GB × $0.00001/MB. Fixed.
- **Infra equivalence**: $95 anchored to the CPX22-overage path (1 Gbps dedicated is $85 infra + $10 gas all-in; listing $95 infra + $10 gas on that path double-counted). Preserves the $478 headline.
- **Price comparison**: "4–20×" → "8–20×" to match the cited CloudFront/Akamai list rates.

## Conventions
Title Case title, H1 dropped, sentence-case section headers, lowercase `decdn`, `summary`/`tags`/`bucket` frontmatter, dated 2026-06-22. Auto-discovered from `content/blog/` — no manifest change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)