### PR TITLE
style(blog): move the pinned-post pin below the date

### DIFF
--- a/components/ui/PostRow.tsx
+++ b/components/ui/PostRow.tsx
@@ -50,36 +50,35 @@ export function PostRow({ post, delay }: { post: PostMeta; delay: number }) {
           {num}
         </span>
 
-        {/* date */}
-        <time
-          dateTime={post.date}
-          className={`${META} hidden self-start opacity-55 @xl:mt-1.5 @xl:block`}
-        >
-          {date}
-        </time>
+        {/* date · pin */}
+        <div className="hidden self-start @xl:mt-1.5 @xl:block">
+          <time dateTime={post.date} className={`${META} block opacity-55`}>
+            {date}
+          </time>
+          {post.pinned && (
+            <span title="Pinned" className="mt-3 block text-whisper">
+              <span className="sr-only">Pinned. </span>
+              {/* Lucide `pin` — stroke art matches the row's line aesthetic */}
+              <svg
+                aria-hidden
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={2}
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="size-5"
+              >
+                <path d="M12 17v5" />
+                <path d="M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V16a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V7a1 1 0 0 1 1-1 2 2 0 0 0 0-4H8a2 2 0 0 0 0 4 1 1 0 0 1 1 1z" />
+              </svg>
+            </span>
+          )}
+        </div>
 
         {/* title · summary · tags */}
         <div className="flex flex-col gap-3">
           <h2 className="hug text-h3 leading-[1.05] font-bold">
-            {post.pinned && (
-              <span title="Pinned" className="mr-2 text-whisper">
-                <span className="sr-only">Pinned. </span>
-                {/* Lucide `pin` — stroke art matches the row's line aesthetic */}
-                <svg
-                  aria-hidden
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth={2}
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  className="inline-block size-[0.8em] -translate-y-px"
-                >
-                  <path d="M12 17v5" />
-                  <path d="M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V16a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V7a1 1 0 0 1 1-1 2 2 0 0 0 0-4H8a2 2 0 0 0 0 4 1 1 0 0 1 1 1z" />
-                </svg>
-              </span>
-            )}
             {post.title}
             {/* terminal-prompt cursor — sits invisible (reserving its
                 width so hover never reflows the line) and fades in


### PR DESCRIPTION
## Summary
- Moves the pinned-post pin out of the post title and into the **date column**, in the empty space below the date.
- **Desktop-only:** the date cell is `hidden @xl:block`, so the pin renders only at `@xl`+; the mobile meta line is untouched.
- Pin sized explicitly (`size-5`) since the old `size-[0.8em]` was relative to the large title font; `mt-3` sets the gap below the date.

## Verification
- `pnpm lint` clean; `pnpm build` succeeds (all 23 routes export).
- Rendered `out/blog/index.html` confirms the pin sits inside the date cell, only on the (pinned) road-to-testnet post — no longer beside the title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)