### PR TITLE
style(blog): shrink and tilt the pinned-post pin icon

### DIFF
--- a/components/ui/PostRow.tsx
+++ b/components/ui/PostRow.tsx
@@ -73,7 +73,7 @@ export function PostRow({ post, delay }: { post: PostMeta; delay: number }) {
                   strokeWidth={2}
                   strokeLinecap="round"
                   strokeLinejoin="round"
-                  className="inline-block size-[0.8em] -translate-y-px"
+                  className="inline-block size-[0.72em] -translate-y-px rotate-[20deg]"
                 >
                   <path d="M12 17v5" />
                   <path d="M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V16a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V7a1 1 0 0 1 1-1 2 2 0 0 0 0-4H8a2 2 0 0 0 0 4 1 1 0 0 1 1 1z" />

--- a/components/ui/PostRow.tsx
+++ b/components/ui/PostRow.tsx
@@ -73,7 +73,7 @@ export function PostRow({ post, delay }: { post: PostMeta; delay: number }) {
                   strokeWidth={2}
                   strokeLinecap="round"
                   strokeLinejoin="round"
-                  className="inline-block size-[0.72em] -translate-y-px rotate-[20deg]"
+                  className="inline-block size-[0.64em] -translate-y-px rotate-[20deg]"
                 >
                   <path d="M12 17v5" />
                   <path d="M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V16a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V7a1 1 0 0 1 1-1 2 2 0 0 0 0-4H8a2 2 0 0 0 0 4 1 1 0 0 1 1 1z" />


### PR DESCRIPTION
## What

Tweaks the green pin icon shown next to pinned blog posts in the post list:

- Smaller: `size-[0.8em]` → `size-[0.64em]`
- Tilted 20° clockwise (leaning right): adds `rotate-[20deg]`

Composes with the existing `-translate-y-px` vertical-align nudge; no color, markup, or accessibility changes.

## Verification

- `pnpm lint` passes.
- Pin renders smaller and tilted right on `/blog/`, still aligned to the title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)