### PR TITLE
style(hero): nudge headline right with an 8vw indent

### DIFF
--- a/components/site/Hero.tsx
+++ b/components/site/Hero.tsx
@@ -12,7 +12,7 @@ export function Hero() {
       <div className="mt-10 flex flex-col gap-8 @4xl:gap-12">
         <h1
           id="intro-h"
-          className="hug flex flex-col text-h1 leading-[0.9] font-semibold tracking-[-0.04em]"
+          className="hug flex flex-col pl-[8vw] text-h1 leading-[0.9] font-semibold tracking-[-0.04em]"
         >
           <span className="rise rise-1">the delivery layer</span>
           <span className="rise rise-2 pl-[7vw]">


### PR DESCRIPTION
Nudges the hero headline rightward so it reads as more centered, while preserving the deliberate staggered-left descending edge.

The indent lives on the `<h1>` itself, so all three lines (`the delivery layer` / `anyone can serve.` / `priced, not quoted.`) shift together and the relative `pl-[7vw]` / `pl-[12vw]` stagger is intact. Only the headline moves — paragraph, CTAs, stats, and the terminal panel are unaffected. `Frame`'s `overflow-hidden` keeps narrow widths from introducing horizontal scroll.

Value tuned by eye across a couple of iterations (6vw → 9vw → 8vw).

🤖 Generated with [Claude Code](https://claude.com/claude-code)