### PR TITLE
fix(blog): stop post reading column overflowing narrow viewports

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -129,7 +129,7 @@ export default async function BlogPost({
       <JsonLd data={postingSchema} />
       <JsonLd data={breadcrumbSchema} />
       <Frame id="post" tone="paper">
-        <article className="flex min-w-0 flex-col gap-10">
+        <article className="flex flex-col gap-10">
           <Link
             href="/blog/"
             aria-label="Back to field notes"

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -129,7 +129,7 @@ export default async function BlogPost({
       <JsonLd data={postingSchema} />
       <JsonLd data={breadcrumbSchema} />
       <Frame id="post" tone="paper">
-        <article className="flex flex-col gap-10">
+        <article className="flex min-w-0 flex-col gap-10">
           <Link
             href="/blog/"
             aria-label="Back to field notes"

--- a/app/globals.css
+++ b/app/globals.css
@@ -858,9 +858,16 @@ a.underline-brutal:hover .arrow {
    in the color-mix() calls below. */
 
 .prose {
+  width: 100%; /* fill the flex column, then cap with max-width. Without an
+                  explicit width, `margin-inline: auto` opts this flex item out
+                  of `align-items: stretch`, so it takes its 68ch max-content
+                  and overflows narrow viewports. */
   max-width: 68ch;
-  margin-inline: auto; /* center the reading column within the wide Frame */
+  min-width: 0;
+  margin-inline: auto; /* center the capped reading column on wide screens */
   color: var(--ink);
+  overflow-wrap: break-word; /* wrap long unbreakable tokens (URLs, rates like
+                                $0.00001/MB) rather than overflow */
 }
 
 .prose > * + * {
@@ -982,6 +989,7 @@ a.underline-brutal:hover .arrow {
   border-bottom: 1px solid color-mix(in srgb, var(--ink) 14%, transparent);
   text-align: left;
   vertical-align: top;
+  overflow-wrap: break-word; /* let cells collapse to fit a narrow column */
 }
 
 .prose th {

--- a/app/globals.css
+++ b/app/globals.css
@@ -989,7 +989,6 @@ a.underline-brutal:hover .arrow {
   border-bottom: 1px solid color-mix(in srgb, var(--ink) 14%, transparent);
   text-align: left;
   vertical-align: top;
-  overflow-wrap: break-word; /* let cells collapse to fit a narrow column */
 }
 
 .prose th {

--- a/app/globals.css
+++ b/app/globals.css
@@ -858,16 +858,21 @@ a.underline-brutal:hover .arrow {
    in the color-mix() calls below. */
 
 .prose {
-  width: 100%; /* fill the flex column, then cap with max-width. Without an
-                  explicit width, `margin-inline: auto` opts this flex item out
-                  of `align-items: stretch`, so it takes its 68ch max-content
-                  and overflows narrow viewports. */
+  width: 100%; /* Pin this flex item to the column width. Its auto cross-axis
+                  margins (margin-inline: auto) opt it out of the flex default
+                  align-items: stretch, so without a definite width it is sized
+                  to content: short content collapses the column, and a child
+                  wider than the viewport (the wide table in post 06) balloons
+                  out to the 68ch max-width and overflows narrow screens.
+                  max-width then acts purely as a cap. */
   max-width: 68ch;
-  min-width: 0;
   margin-inline: auto; /* center the capped reading column on wide screens */
   color: var(--ink);
-  overflow-wrap: break-word; /* wrap long unbreakable tokens (URLs, rates like
-                                $0.00001/MB) rather than overflow */
+  overflow-wrap: break-word; /* break long unbreakable inline tokens (long
+                                inline code, external links) so they wrap
+                                instead of overflowing the column. Fenced code
+                                blocks are unaffected — they scroll via
+                                .prose pre { overflow-x: auto }. */
 }
 
 .prose > * + * {


### PR DESCRIPTION
## Problem

On mobile, blog post pages (e.g. post 06, *Show Me the Money*) rendered the reading column — paragraphs and tables — **wider than the screen**, clipped on the right with a black gutter and horizontal page scroll.

## Root cause

`.prose` is a flex item inside `<article className="flex flex-col">` (a **column** flex container), and it carries `margin-inline: auto`. Auto margins on a flex item's cross axis **opt it out of `align-items: stretch`** — so instead of filling the column and being capped by `max-width`, `.prose` was sized to its content. When a child's intrinsic width exceeds the viewport (the wide data table in post 06), the column balloons out to its `max-width: 68ch` (~605px) and overflows narrow screens; every paragraph then fills that over-wide column, hence the clipping.

## Fix

One declaration carries it, plus a wrapping safety net — net diff is a single rule in `app/globals.css`:

```css
.prose {
  width: 100%;               /* pin the flex item to the column width; max-width becomes a pure cap */
  max-width: 68ch;
  margin-inline: auto;       /* still centers the capped column on wide screens */
  color: var(--ink);
  overflow-wrap: break-word; /* break long unbreakable inline tokens so they wrap, not overflow */
}
```

- **`width: 100%`** is the behavioral fix: a definite cross-axis size means the item fills the column and is then capped/centered by `max-width` + `margin-inline: auto`.
- **`overflow-wrap: break-word`** is independently load-bearing: even with `width: 100%`, a long unbreakable inline token would still overflow unless allowed to break. It's inherited, so it also covers table cells.

Desktop is unchanged: the column still resolves to `min(100%, 68ch)` and stays centered.

### Review follow-up (later commits)

- Dropped a redundant cell-level `overflow-wrap` (inherited from `.prose`).
- Dropped `min-width: 0` / `min-w-0` that an initial attempt added — verified to be **no-ops** here (the flexbox auto-minimum applies only to the *main* axis, and both containers are `flex-col`, so cross-axis `min-width` already resolves to `0`; `width: 100%` makes the size definite regardless). An A/B render at 390px was byte-identical with and without them.

## Verification

- Built the static export; confirmed shipped CSS: `.prose{width:100%;max-width:68ch;color:…;overflow-wrap:break-word;margin-inline:auto}`.
- Rendered the real post inside a **true 390px** iframe (headless Chrome clamps its own viewport to 500px, so an iframe gives the honest phone width): full-width column, paragraphs wrap, no clipping, `scrollWidth == clientWidth`.
- Desktop (~1280px) unchanged: column centered at `max-width: 68ch`.
- `pnpm lint` and `pnpm exec prettier --check` pass.
- Cloudflare Pages preview: https://fix-blog-mobile-overflow.website-70y.pages.dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)