### PR TITLE
fix(contact): equalize github link spacing on phones

### DIFF
--- a/components/site/Contact.tsx
+++ b/components/site/Contact.tsx
@@ -113,7 +113,7 @@ export function Contact() {
           <div
             data-reveal
             style={{ "--reveal-delay": "220ms" }}
-            className="flex flex-col gap-y-8"
+            className="flex flex-col gap-y-4 @md:gap-y-8"
           >
             <div className="flex flex-col flex-wrap gap-x-10 gap-y-4 @md:flex-row @md:items-baseline">
               <a


### PR DESCRIPTION
## Context

In the Contact section, the four social links (email, linkedin, x, github) are split across two flex containers so the desktop layout can render email/linkedin/x as one inline row with github on its own line below. The parent wrapper separated those containers with `gap-y-8` (2rem), while the three links inside the first container stack with `gap-y-4` (1rem).

On desktop this reads as a deliberate two-line grouping. On phones every link stacks vertically, so the three top links sat 1rem apart while github was pushed 2rem away — the gap was visibly unequal.

## Change

Single class edit on the links wrapper in `components/site/Contact.tsx`:

```
- className="flex flex-col gap-y-8"
+ className="flex flex-col gap-y-4 @md:gap-y-8"
```

- **On phones** (below `@md`): wrapper gap becomes `gap-y-4`, matching the inner spacing so all four links are evenly spaced.
- **At `@md` and up**: gap returns to `gap-y-8` — exactly where the first container flips to `@md:flex-row`, so the intentional desktop two-row grouping is preserved.

## Verification

- `pnpm lint` passes.
- At ~375px width the vertical gaps between email → linkedin → x → github are equal.
- Above the `@md` breakpoint the desktop layout (inline row + github below, 2rem gap) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted spacing in the contact section so elements appear more compact on smaller screens and keep wider spacing on larger screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->