### PR TITLE
docs: sync readme and agents.md with current codebase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,11 +25,12 @@ pnpm format:check     # prettier --check . (CI)
 
 ## Layout
 
-- `app/` — App Router entry (`layout.tsx`, `page.tsx`, `globals.css`), the `blog/` and `blog/[slug]/` routes, the `robots.txt/route.ts` / `sitemap.xml/route.ts` / `sitemap-pages.xml/route.ts` handlers, and the file-convention assets (`favicon.ico`, `icon.svg`, `apple-icon.png`, `opengraph-image.{png,alt.txt}`).
-- `components/site/` — page sections composed by `app/page.tsx` (Hero, Compare, Method, Faq, Contact, …) plus chrome (`Chrome`, `Footer`, `ScrollReveal`). Section components are named after their section `id` (e.g. `Contact.tsx` for `id="contact"`); `Hero` is the idiomatic exception for the top `id="intro"` section.
+- `app/` — App Router entry (`layout.tsx`, `page.tsx`, `globals.css`), the `blog/` and `blog/[slug]/` routes, the `legal/[doc]` route, the `robots.txt/route.ts` / `sitemap.xml/route.ts` / `sitemap-pages.xml/route.ts` handlers, and the file-convention assets (`favicon.ico`, `icon.svg`, `apple-icon.png`, `opengraph-image.{png,alt.txt}`).
+- `components/site/` — page sections composed by `app/page.tsx` (Hero, Compare, Method, Faq, Contact, …) plus chrome (`Chrome`, `Footer`, `ScrollReveal`, …). Section components are named after their section `id` (e.g. `Contact.tsx` for `id="contact"`); `Hero` is the idiomatic exception for the top `id="intro"` section.
 - `components/ui/` — low-level primitives (Frame, SectionHeader, Prose, Figure, …).
-- `lib/` — shared helpers (`links.ts`, `blog.ts`, `faq.ts`, `jsonld.tsx`).
+- `lib/` — shared helpers (`links.ts`, `blog.ts`, `faq.ts`, `legal.ts`, `jsonld.tsx`, …).
 - `content/blog/` — MDX posts loaded by `lib/blog.ts` and rendered via `app/blog/[slug]/page.tsx`.
+- `content/legal/` — MDX for the legal pages (`privacy`, `terms`, `disclaimer`) loaded by `lib/legal.ts` and rendered via `app/legal/[doc]/page.tsx`.
 - `docs/` — Mintlify source for `docs.decdn.org` (separate build pipeline, not part of the static export).
 - Path alias `@/*` → project root (e.g. `@/lib/links`, not `@/src/...`).
 
@@ -39,6 +40,6 @@ pnpm format:check     # prettier --check . (CI)
 - **`trailingSlash: true`.** `next.config.ts` emits every route as `<path>/index.html` and canonical/internal links should expect a trailing slash. Cloudflare Pages serves `out/` as-is.
 - **Tailwind v4.** `globals.css` uses `@import "tailwindcss"` and `@theme inline { … }`. There is no `tailwind.config.*` — theme tokens live in CSS. Don't reach for v3 directives.
 - **Conventional commits required.** `commitlint` runs in the `commit-msg` husky hook; non-conforming messages are rejected.
-- **`metadataBase` is live.** `lib/links.ts` `site` is the real origin and `INDEXABLE` is `true`. Anything anchored on this origin — OG and canonical (via `metadataBase`); JSON-LD, `app/sitemap.xml/route.ts`, `app/sitemap-pages.xml/route.ts`, `app/robots.ts` (via `SITE_URL`) — ships to production. Adding a new non-blog page = append an entry to `app/sitemap-pages.xml/route.ts`; new blog posts are auto-derived from `content/blog/`. Flip `INDEXABLE` to mark pages noindex; `robots.txt` and the sitemap remain unchanged by design (see `lib/links.ts` for why).
+- **`metadataBase` is live.** `lib/links.ts` `site` is the real origin and `INDEXABLE` is `true`. Anything anchored on this origin — OG and canonical (via `metadataBase`); JSON-LD, `app/sitemap.xml/route.ts`, `app/sitemap-pages.xml/route.ts`, `app/robots.txt/route.ts` (via `SITE_URL`) — ships to production. Adding a new non-blog page = append an entry to `app/sitemap-pages.xml/route.ts`; blog posts auto-derive from `content/blog/` and legal pages from the closed `LEGAL_SLUGS` list in `lib/legal.ts`. Flip `INDEXABLE` to mark pages noindex; `robots.txt` and the sitemap remain unchanged by design (see `lib/links.ts` for why).
 - **`docs/` is a different product.** Mintlify Cloud builds it from `docs/docs.json` and serves it at `docs.decdn.org` — independent of `pnpm build`. The website code must not import from `docs/`; ESLint and the website CI workflow ignore it. Edits to MDX go through the `docs` workflow (Prettier + `markdownlint-cli2` + `mintlify broken-links`).
 - **CSS custom properties in `style` props.** Known `--var` names are declared in `types/css.d.ts` (module-augmenting React's `CSSProperties`) so call sites can write `style={{ "--reveal-delay": "120ms" }}` without a cast. Add new vars there before using them.

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ pnpm format    # prettier --write .
 ## Project layout
 
 - `app/` — App Router entry (`layout.tsx`, `page.tsx`, `globals.css`) plus the blog routes (`blog/`, `blog/[slug]/`), the `legal/[doc]` route, sitemap/robots handlers, and file-convention metadata assets.
-- `components/site/` — page sections composed by `app/page.tsx` (Hero, Compare, Method, Faq, Contact, …) plus chrome (`Chrome`, `Footer`, `ScrollReveal`).
+- `components/site/` — page sections composed by `app/page.tsx` (Hero, Compare, Method, Faq, Contact, …) plus chrome (`Chrome`, `Footer`, `ScrollReveal`, …).
 - `components/ui/` — low-level primitives (Frame, SectionHeader, Prose, Figure, …).
-- `lib/` — shared helpers (`links.ts`, `blog.ts`, `faq.ts`, `legal.ts`, `jsonld.tsx`).
+- `lib/` — shared helpers (`links.ts`, `blog.ts`, `faq.ts`, `legal.ts`, `jsonld.tsx`, …).
 - `content/blog/` — MDX posts loaded by `lib/blog.ts` and rendered by `app/blog/[slug]/page.tsx`.
 - `content/legal/` — MDX for the legal pages (`privacy`, `terms`, `disclaimer`), loaded by `lib/legal.ts` and rendered by `app/legal/[doc]/page.tsx`.
 - `docs/` — Mintlify source for `docs.decdn.org`. Built and deployed independently of `pnpm build`; not part of the static export and not imported from the website code.
@@ -45,7 +45,7 @@ pnpm format    # prettier --write .
 - **`trailingSlash: true`.** Every route emits `<path>/index.html`. Internal links and hand-built URLs (sitemap entries, JSON-LD `@id`s) should expect a trailing slash — see `SITE_URL` and `BLOG_URL` in `lib/links.ts`.
 - **Tailwind v4.** Theme tokens live in `app/globals.css` under `@theme inline { … }` — there is no `tailwind.config.*`.
 - **Conventional commits enforced.** `commitlint` runs in the `commit-msg` husky hook; non-conforming messages are rejected.
-- **`metadataBase` is live.** `lib/links.ts` `site` is the real origin and `INDEXABLE` is `true`. Anything anchored on this origin — OG and canonical (via `metadataBase`); JSON-LD and the sitemap/robots emitters (via `SITE_URL`) — ships to production. Adding a non-blog page means appending an entry to `app/sitemap-pages.xml/route.ts`; blog and legal pages are auto-derived from `content/`. Flipping `INDEXABLE` flips `<meta name="robots">` only; `robots.txt` and the sitemap stay unconditional by design (rationale in `lib/links.ts`).
+- **`metadataBase` is live.** `lib/links.ts` `site` is the real origin and `INDEXABLE` is `true`. Anything anchored on this origin — OG and canonical (via `metadataBase`); JSON-LD and the sitemap/robots emitters (via `SITE_URL`) — ships to production. Adding a non-blog page means appending an entry to `app/sitemap-pages.xml/route.ts`; blog posts are auto-derived from `content/blog/`, while legal pages are driven by the closed `LEGAL_SLUGS` list in `lib/legal.ts` (add both the MDX file under `content/legal/` and a slug there). Flipping `INDEXABLE` flips `<meta name="robots">` only; `robots.txt` and the sitemap stay unconditional by design (rationale in `lib/links.ts`).
 
 ## Deploy
 

--- a/README.md
+++ b/README.md
@@ -30,21 +30,22 @@ pnpm format    # prettier --write .
 
 ## Project layout
 
-- `app/` — App Router entry (`layout.tsx`, `page.tsx`, `globals.css`) plus the blog routes (`blog/`, `blog/[slug]/`), sitemap/robots handlers, and file-convention metadata assets.
-- `components/site/` — page sections composed by `app/page.tsx` (Hero, Compare, Method, Faq, Contact).
-- `components/ui/` — low-level primitives (Frame, SectionHeader, Figure, …).
-- `lib/` — shared helpers (`links.ts`, `blog.ts`, `faq.ts`, `jsonld.tsx`).
+- `app/` — App Router entry (`layout.tsx`, `page.tsx`, `globals.css`) plus the blog routes (`blog/`, `blog/[slug]/`), the `legal/[doc]` route, sitemap/robots handlers, and file-convention metadata assets.
+- `components/site/` — page sections composed by `app/page.tsx` (Hero, Compare, Method, Faq, Contact, …) plus chrome (`Chrome`, `Footer`, `ScrollReveal`).
+- `components/ui/` — low-level primitives (Frame, SectionHeader, Prose, Figure, …).
+- `lib/` — shared helpers (`links.ts`, `blog.ts`, `faq.ts`, `legal.ts`, `jsonld.tsx`).
 - `content/blog/` — MDX posts loaded by `lib/blog.ts` and rendered by `app/blog/[slug]/page.tsx`.
+- `content/legal/` — MDX for the legal pages (`privacy`, `terms`, `disclaimer`), loaded by `lib/legal.ts` and rendered by `app/legal/[doc]/page.tsx`.
 - `docs/` — Mintlify source for `docs.decdn.org`. Built and deployed independently of `pnpm build`; not part of the static export and not imported from the website code.
 - Path alias: `@/*` maps to the project root (e.g. `@/lib/links`, not `@/src/...`).
 
 ## Gotchas
 
-- **Static export only.** `next.config.ts` sets `output: "export"`; the build emits `./out`. No SSR, ISR, middleware, or Image Optimization API. Route handlers (`app/sitemap.xml/route.ts`, `app/sitemap-pages.xml/route.ts`) must be `dynamic = "force-static"` and GET-only; the `app/robots.ts` metadata file emits `robots.txt` and also requires `dynamic = "force-static"`.
+- **Static export only.** `next.config.ts` sets `output: "export"`; the build emits `./out`. No SSR, ISR, middleware, or Image Optimization API. Route handlers (`app/robots.txt/route.ts`, `app/sitemap.xml/route.ts`, `app/sitemap-pages.xml/route.ts`) must be `dynamic = "force-static"` and GET-only. `robots.txt` is a hand-written route handler rather than the Next `app/robots.ts` metadata file, so it can emit the non-standard `Content-Signal:` directive (per contentsignals.org).
 - **`trailingSlash: true`.** Every route emits `<path>/index.html`. Internal links and hand-built URLs (sitemap entries, JSON-LD `@id`s) should expect a trailing slash — see `SITE_URL` and `BLOG_URL` in `lib/links.ts`.
 - **Tailwind v4.** Theme tokens live in `app/globals.css` under `@theme inline { … }` — there is no `tailwind.config.*`.
 - **Conventional commits enforced.** `commitlint` runs in the `commit-msg` husky hook; non-conforming messages are rejected.
-- **`metadataBase` is live.** `lib/links.ts` `site` is the real origin and `INDEXABLE` is `true`. Anything anchored on this origin — OG and canonical (via `metadataBase`); JSON-LD and the sitemap/robots emitters (via `SITE_URL`) — ships to production. Flipping `INDEXABLE` flips `<meta name="robots">` only; `robots.txt` and the sitemap stay unconditional by design (rationale in `lib/links.ts`).
+- **`metadataBase` is live.** `lib/links.ts` `site` is the real origin and `INDEXABLE` is `true`. Anything anchored on this origin — OG and canonical (via `metadataBase`); JSON-LD and the sitemap/robots emitters (via `SITE_URL`) — ships to production. Adding a non-blog page means appending an entry to `app/sitemap-pages.xml/route.ts`; blog and legal pages are auto-derived from `content/`. Flipping `INDEXABLE` flips `<meta name="robots">` only; `robots.txt` and the sitemap stay unconditional by design (rationale in `lib/links.ts`).
 
 ## Deploy
 


### PR DESCRIPTION
## Summary

Brings the two project docs — `README.md` and `AGENTS.md` (the authoritative ruleset) — back in sync with the current codebase and with each other. Both had drifted: they documented a `robots.txt` mechanism that no longer exists, omitted the legal pages/route added since, and listed only a subset of components. A comprehensive review of the initial README sync surfaced that `AGENTS.md` was itself stale (and self-contradicting), so it's fixed here too.

## Changes

### `README.md`
- **Fix stale `robots.txt` gotcha** — it's a hand-written route handler at `app/robots.txt/route.ts` (emitting the non-standard `Content-Signal:` directive per contentsignals.org), *not* the Next `app/robots.ts` metadata file. Route-handler list now includes all three (`robots.txt`, `sitemap.xml`, `sitemap-pages.xml`).
- **Document the legal surface** — `app/legal/[doc]` route, `content/legal/` (`privacy`, `terms`, `disclaimer`), and `lib/legal.ts`.
- **Complete the component & lib lists** — add chrome (`Chrome`, `Footer`, `ScrollReveal`), `Prose`, and `lib/legal.ts`.
- **Clarify the new-page workflow** — non-blog pages append to `app/sitemap-pages.xml/route.ts`; blog posts auto-derive from `content/blog/`, while legal pages are driven by the closed `LEGAL_SLUGS` list in `lib/legal.ts`.
- **Mark representative lists non-exhaustive** — `chrome` and `lib` lists carry a trailing `…`.

### `AGENTS.md`
- **Fix self-contradiction** — line 42 referenced `app/robots.ts` (which doesn't exist) while line 38 correctly names `robots.txt/route.ts`. Now consistent.
- **Document the legal surface** — add the `legal/[doc]` route to the `app/` layout line and a `content/legal/` entry; add `legal.ts` to the `lib/` list.
- **Match the README `…` convention** — chrome and `lib` lists now marked non-exhaustive.
- **Correct the auto-derivation clause** — legal pages derive from `LEGAL_SLUGS`, not the generic sitemap-append step.

## Review response

Commit `ecf0ab6` addressed the automated review (CodeRabbit — legal-derivation contract; Gemini — non-exhaustive `…` markers). A follow-up comprehensive review then flagged the `AGENTS.md` drift, fixed in `b87a8d7`.

## Verification

- `pnpm exec prettier --check README.md AGENTS.md` passes (husky/lint-staged clean on all commits).
- Every named path verified against the current tree (`app/`, `components/site`, `components/ui`, `lib/`, `content/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated project documentation to include the new legal pages structure alongside the blog setup.
  - Added references to the legal content source, route, and related UI components.
  - Clarified notes about site metadata and how robots directives and indexing behave.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->